### PR TITLE
Initial set-up for the Assessment Service repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
-# Add a team or username to this file
-# Example:
-# *   @ministryofjustice/github-community
+# GitHub users/groups automatically requested to review App code on PR
+* @ministryofjustice/laa-crime-apps-team

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,31 +7,11 @@
 version: 2
 
 updates:
-  - package-ecosystem: "bundler"
-    directory: "/"
+  - package-ecosystem: "gradle"
+    directory: "/crime-assessment-service"
     schedule:
-      interval: "daily"
-  - package-ecosystem: "terraform"
-    directory: "/terraform"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "daily"
+      interval: "weekly"
+    commit-message:
+      prefix: "Gradle"
+      include: "scope"
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## What
+
+[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-XXX)
+
+Describe what you did and why.
+
+## Checklist
+
+Before you ask people to review this PR:
+
+- [ ] Tests should be passing: `./gradlew test`
+- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
+- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
+- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
+- [ ] You should have checked that the commit messages say why the change was made.
+
+## Additional checks
+
+- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,52 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 8 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: 'ubuntu-latest'
+    permissions:
+      # required for all workflows
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ "java" ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Add any setup steps before running the `github/codeql-action/init` action.
+      # This includes steps like installing compilers or runtimes (`actions/setup-node`
+      # or others). This is typically only required for manual builds.
+      # - name: Setup runtime (example)
+      #   uses: actions/setup-example@v1
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .env
+.java-version
+.idea/
 .terraform/
 coverage/
 venv/

--- a/README.md
+++ b/README.md
@@ -1,70 +1,68 @@
-# Ministry of Justice Template Repository
+# Crime Assessment Service
 
-[![Ministry of Justice Repository Compliance Badge](https://github-community.service.justice.gov.uk/repository-standards/api/template-repository/badge)](https://github-community.service.justice.gov.uk/repository-standards/template-repository)
+The Crime Assessment Service is a Spring Modulith application which handles multiple types of assessments that can be made as part of a criminal legal aid application. These include but are not limited to: means assessments, Interest of Justice (IoJ) appeals, passported benefits and hardship reviews. Each of the different assessment types is encapsulated within a separate application module.
 
-This template repository equips you with the default initial files required for a Ministry of Justice GitHub repository.
+The main consumer of the Crime Assessment Service is the Orchestration Service, which previously made requests to many of the individual microservices that now live within this service.
 
-## Included Files
+[![Ministry of Justice Repository Compliance Badge](https://github-community.service.justice.gov.uk/repository-standards/api/laa-crime-assessment-service/badge)](https://github-community.service.justice.gov.uk/repository-standards/laa-crime-assessment-service)
 
-The repository comes with the following preset files:
+## Technical documentation
 
-- LICENSE
-- .gitignore
-- CODEOWNERS
-- dependabot.yml
-- GitHub Actions example files
-- Ministry of Justice Compliance Badge (public repositories only)
+This service uses Java 21 and is built using Spring Modulith. It is hosted on the Moj Cloud Platform and runs within Kubernetes.
 
-## Setup Instructions
+## Getting started
 
-Once you've created your repository using this template, ensure the following steps:
+### Application set-up
 
-### Update README
+```
+git clone git@github.com:ministryofjustice/laa-crime-assessment-service.git
 
-Edit this README.md file to document your project accurately. Take the time to create a clear, engaging, and informative README.md file. Include information like what your project does, how to install and run it, how to contribute, and any other pertinent details.
-
-### Update repository description
-
-After you've created your repository, GitHub provides a brief description field that appears on the top of your repository's main page. This is a summary that gives visitors quick insight into the project. Using this field to provide a succinct overview of your repository is highly recommended.
-
-This description and your README.md will be one of the first things people see when they visit your repository. It's a good place to make a strong, concise first impression. Remember, this is often visible in search results on GitHub and search engines, so it's also an opportunity to help people discover your project.
-
-### Grant Team Permissions
-
-Assign permissions to the appropriate Ministry of Justice teams. Ensure at least one team is granted Admin permissions. Whenever possible, assign permissions to teams rather than individual users.
-
-Prefer to user GitHub Teams over individual access to repositories. Where appropriate, ensure GitHub Teams used are related to a Parent Team associated with a Business Unit to help ensure ownership can be easily identified.
-
-### Read about the GitHub repository standards
-
-Familiarise yourself with the Ministry of Justice GitHub Repository Standards. These standards ensure consistency, maintainability, and best practices across all our repositories.
-
-You can find the standards [here](https://github-community.service.justice.gov.uk/repository-standards/guidance).
-
-Please read and understand these standards thoroughly and enable them when you feel comfortable.
-
-### Modify the GitHub Standards Badge
-
-Once you've ensured that all the [GitHub Repository Standards](https://github-community.service.justice.gov.uk/repository-standards/guidance) have been applied to your repository, it's time to update the Ministry of Justice (MoJ) Compliance Badge located in the README file.
-
-The badge demonstrates that your repository is compliant with MoJ's standards.
-
-To update the badge, replace the `template-repository` in the badge URL with your repository's name. The badge URL should look like this:
-
-```markdown
-[![Ministry of Justice Repository Compliance Badge](https://github-community.service.justice.gov.uk/repository-standards/api/${your-repository-name}/badge)](https://github-community.service.justice.gov.uk/repository-standards/${your-reposistory-name})
+cd laa-crime-assessment-service
 ```
 
-**Please note** the badge will not function correctly if your repository is internal or private. In this case, you may remove the badge from your README.
+### Java set-up
 
-### Update CODEOWNERS
+If you do not already have Java 21 installed, you will need to install it. There are many ways to do this, but a recommended approach
+is to use [jenv](https://github.com/jenv/jenv) to manage your local Java versions and enable easy switching between them. jenv will
+also automatically switch to use the correct Java version when you navigate to a project containing a `.java-version` file (providing
+it is already installed).
 
-(Optional) Modify the CODEOWNERS file to specify the teams or users authorized to approve pull requests.
+```sh
+# Check your current Java version - if it is Java 21 then the rest of the following steps are optional
+java -version
 
-### Configure Dependabot
+brew update
 
-Adapt the dependabot.yml file to match your project's [dependency manager](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem) and to enable [automated pull requests for package updates](https://docs.github.com/en/code-security/supply-chain-security).
+brew install jenv
+brew install openjdk@21
 
-### Dependency Review
+# See the output from the previous command to determine where Java 21 was installed
+# You may need to symlink to your JavaVirtualMachines directory from the installed location to be able to use it
+jenv add /path/to/Java/Contents/Home
 
-If your repository is private with no GitHub Advanced Security license, remove the `.github/workflows/dependency-review.yml` file.
+# Check to ensure that you can see Java 21 now listed
+jenv versions
+
+# Switch to Java 21 (ensure you're still inside the laa-crime-assessment-service directory)
+jenv local 21
+
+# Confirm that Java 21 is now the current Java version
+java -version
+```
+
+### Running tests
+
+To build the project:
+
+```sh
+./gradlew clean build
+```
+
+Ensure that all tests are passing by running:
+
+```sh
+./gradlew clean test
+```
+
+Note: the `clean` task in the above two commands is optional but ensures that the build directory is
+removed first, ensuring that there are no leftovers remaining of previous builds.


### PR DESCRIPTION
This PR adds some initial set-up for the Assessment Service repo, specifically updates to the README with basic information about the service, a pull request template, code owners for pull requests and additional exclusions via the .gitignore file.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1702)