### PR TITLE
Add missing Prometheus dependency

### DIFF
--- a/crime-assessment-service/build.gradle
+++ b/crime-assessment-service/build.gradle
@@ -52,6 +52,9 @@ dependencies {
     implementation platform("io.sentry:sentry-bom:$versions.sentry")
     implementation("io.sentry:sentry-spring-boot-starter-jakarta")
     implementation("io.sentry:sentry-logback")
+
+    // Prometheus
+    implementation "io.micrometer:micrometer-registry-prometheus"
     
     // Testing
     testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
This PR adds a missing Prometheus dependency to the project. The service was previously set up to expose metrics to be scraped by Prometheus, however the Prometheus library itself was not added, meaning that no data is currently available in Prometheus.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1858)