### PR TITLE
Add MAAT API web client and supporting classes

### DIFF
--- a/crime-assessment-service/build.gradle
+++ b/crime-assessment-service/build.gradle
@@ -97,7 +97,13 @@ jacocoTestCoverageVerification {
         rule {
             element = 'CLASS'
             // placeholder exclude for ease of modification.
-            excludes = ['uk.gov.justice.laa.crime.assessmentservice.AssessmentServiceApplication', 'uk.gov.justice.laa.crime.assessmentservice.iojappeal.IojAppealController','uk.gov.justice.laa.crime.assessmentservice.passport.PassportController']
+            excludes = ['uk.gov.justice.laa.crime.assessmentservice.AssessmentServiceApplication',
+                        'uk.gov.justice.laa.crime.assessmentservice.ServicesConfiguration',
+                        'uk.gov.justice.laa.crime.assessmentservice.WebClientsConfiguration',
+                        'uk.gov.justice.laa.crime.assessmentservice.iojappeal.IojAppealController',
+                        'uk.gov.justice.laa.crime.assessmentservice.passport.PassportController',
+                        'uk.gov.justice.laa.crime.assessmentservice.common.filter.*'
+            ]
             limit {
                 minimum = 0.8
             }

--- a/crime-assessment-service/build.gradle
+++ b/crime-assessment-service/build.gradle
@@ -16,7 +16,8 @@ java {
 }
 
 def versions = [
-        sentry  : "8.23.0"
+    sentry          : "8.23.0",
+    resilience4j    : "2.3.0"
 ]
 
 repositories {
@@ -44,10 +45,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-configuration-processor'
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
     implementation "org.springframework.boot:spring-boot-starter-validation"
+    implementation "org.springframework.boot:spring-boot-starter-oauth2-client"
     
     // Database
     implementation 'org.postgresql:postgresql'
     implementation 'org.liquibase:liquibase-core'
+
+    // Resilience4j
+    implementation "io.github.resilience4j:resilience4j-reactor:$versions.resilience4j"
+    implementation "io.github.resilience4j:resilience4j-spring-boot3:$versions.resilience4j"
 
     // Sentry
     implementation platform("io.sentry:sentry-bom:$versions.sentry")
@@ -67,8 +73,10 @@ dependencies {
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6"
     
     compileOnly 'org.projectlombok:lombok:1.18.38'
-    
     annotationProcessor 'org.projectlombok:lombok:1.18.38'
+
+    testCompileOnly "org.projectlombok:lombok:1.18.38"
+    testAnnotationProcessor "org.projectlombok:lombok:1.18.38"
 }
 
 tasks.named('test') {

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/ServicesConfiguration.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/ServicesConfiguration.java
@@ -1,0 +1,29 @@
+package uk.gov.justice.laa.crime.assessmentservice;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "services")
+public class ServicesConfiguration {
+    @NotNull
+    private MaatApi maatApi;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class MaatApi {
+
+        @NotNull
+        private String baseUrl;
+
+        @NotNull
+        private String registrationId;
+    }
+}

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/WebClientsConfiguration.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/WebClientsConfiguration.java
@@ -1,0 +1,70 @@
+package uk.gov.justice.laa.crime.assessmentservice;
+
+import io.github.resilience4j.retry.RetryRegistry;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import uk.gov.justice.laa.crime.assessmentservice.common.client.MaatCourtDataApiClient;
+import uk.gov.justice.laa.crime.assessmentservice.common.filter.Resilience4jRetryFilter;
+import uk.gov.justice.laa.crime.assessmentservice.common.filter.WebClientFilters;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.support.WebClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+@Slf4j
+@Configuration
+@AllArgsConstructor
+public class WebClientsConfiguration {
+    public static final String MAAT_API_CLIENT_NAME = "maatCourtDataWebClient";
+
+    @Bean(MAAT_API_CLIENT_NAME)
+    WebClient maatCourtDataWebClient(
+            WebClient.Builder webClientBuilder,
+            ServicesConfiguration servicesConfiguration,
+            ClientRegistrationRepository clientRegistrations,
+            OAuth2AuthorizedClientRepository authorizedClients,
+            RetryRegistry retryRegistry) {
+
+        ServletOAuth2AuthorizedClientExchangeFilterFunction oauthFilter =
+                new ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrations, authorizedClients);
+        oauthFilter.setDefaultClientRegistrationId(
+                servicesConfiguration.getMaatApi().getRegistrationId());
+
+        Resilience4jRetryFilter retryFilter = new Resilience4jRetryFilter(retryRegistry, MAAT_API_CLIENT_NAME);
+
+        return webClientBuilder
+                .baseUrl(servicesConfiguration.getMaatApi().getBaseUrl())
+                .filters(filters -> configureFilters(filters, oauthFilter, retryFilter))
+                .build();
+    }
+
+    @Bean
+    MaatCourtDataApiClient maatCourtDataApiClient(
+            @Qualifier("maatCourtDataWebClient") WebClient maatCourtDataWebClient) {
+        HttpServiceProxyFactory httpServiceProxyFactory = HttpServiceProxyFactory.builderFor(
+                        WebClientAdapter.create(maatCourtDataWebClient))
+                .build();
+        return httpServiceProxyFactory.createClient(MaatCourtDataApiClient.class);
+    }
+
+    private void configureFilters(
+            List<ExchangeFilterFunction> filters,
+            ServletOAuth2AuthorizedClientExchangeFilterFunction oauthFilter,
+            ExchangeFilterFunction retryFilter) {
+        filters.add(WebClientFilters.logRequestHeaders());
+        filters.add(retryFilter);
+        filters.add(oauthFilter);
+        filters.add(WebClientFilters.errorResponseHandler());
+        filters.add(WebClientFilters.handleNotFoundResponse());
+        filters.add(WebClientFilters.logResponse());
+    }
+}

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/client/MaatCourtDataApiClient.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/client/MaatCourtDataApiClient.java
@@ -1,0 +1,13 @@
+package uk.gov.justice.laa.crime.assessmentservice.common.client;
+
+import uk.gov.justice.laa.crime.assessmentservice.common.dto.IojAppealDTO;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+
+@HttpExchange()
+public interface MaatCourtDataApiClient {
+    @GetExchange("/api/internal/v1/assessment/ioj-appeal/{legacyAppealId}")
+    IojAppealDTO getIojAppeal(@PathVariable Integer legacyAppealId);
+}

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/dto/IojAppealDTO.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/dto/IojAppealDTO.java
@@ -1,0 +1,14 @@
+package uk.gov.justice.laa.crime.assessmentservice.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class IojAppealDTO {
+    private Integer appealId;
+}

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/filter/Resilience4jRetryFilter.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/filter/Resilience4jRetryFilter.java
@@ -1,0 +1,44 @@
+package uk.gov.justice.laa.crime.assessmentservice.common.filter;
+
+import io.github.resilience4j.reactor.retry.RetryOperator;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryRegistry;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+import java.util.Set;
+
+import org.springframework.lang.NonNull;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+
+@Slf4j
+public class Resilience4jRetryFilter implements ExchangeFilterFunction {
+
+    private final Retry retry;
+    private static final String DEFAULT_RETRY = "default";
+
+    public Resilience4jRetryFilter(RetryRegistry retryRegistry, String clientName) {
+        Set<String> availableRetries =
+                retryRegistry.getAllRetries().stream().map(Retry::getName).collect(java.util.stream.Collectors.toSet());
+
+        String retryName = availableRetries.contains(clientName) ? clientName : DEFAULT_RETRY;
+        retry = retryRegistry.retry(retryName);
+
+        retry.getEventPublisher()
+                .onSuccess(event -> log.info("✅ Request succeeded after {} attempts", event.getNumberOfRetryAttempts()))
+                .onRetry(event -> log.info(
+                        "🔄 Retry #{} after {}ms for request",
+                        event.getNumberOfRetryAttempts(),
+                        event.getWaitInterval().toMillis()))
+                .onError(event -> log.error(
+                        "🚨 Request failed after {} retry attempts. Giving up.", event.getNumberOfRetryAttempts()));
+    }
+
+    @Override
+    public @NonNull Mono<ClientResponse> filter(@NonNull ClientRequest request, @NonNull ExchangeFunction next) {
+        return next.exchange(request).transformDeferred(RetryOperator.of(retry));
+    }
+}

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/filter/WebClientFilters.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/filter/WebClientFilters.java
@@ -1,0 +1,61 @@
+package uk.gov.justice.laa.crime.assessmentservice.common.filter;
+
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+
+@Slf4j
+@UtilityClass
+public class WebClientFilters {
+
+    public static ExchangeFilterFunction logResponse() {
+        return ExchangeFilterFunction.ofResponseProcessor(clientResponse -> {
+            if (clientResponse.statusCode().is2xxSuccessful()
+                    || clientResponse.statusCode().isSameCodeAs(HttpStatus.NOT_FOUND)) {
+                log.info("✅ Response status: {}", clientResponse.statusCode());
+            } else if (clientResponse.statusCode().is4xxClientError()
+                    || clientResponse.statusCode().is5xxServerError()) {
+                log.error("❌  Response status: {}", clientResponse.statusCode());
+            }
+            return Mono.just(clientResponse);
+        });
+    }
+
+    public static ExchangeFilterFunction logRequestHeaders() {
+        return (clientRequest, next) -> {
+            log.info("Request: {} {}", clientRequest.method(), clientRequest.url());
+            clientRequest.headers().forEach((name, values) -> {
+                if (!name.equals(HttpHeaders.AUTHORIZATION)) {
+                    values.forEach(value -> log.debug("{}={}", name, value));
+                }
+            });
+            return next.exchange(clientRequest);
+        };
+    }
+
+    public static ExchangeFilterFunction handleNotFoundResponse() {
+        return ExchangeFilterFunction.ofResponseProcessor(response -> {
+            if (response.statusCode() == HttpStatus.NOT_FOUND) {
+                // Create a synthetic successful response (200 OK) with an empty body.
+                return response.bodyToMono(Void.class)
+                        .then(Mono.just(ClientResponse.create(HttpStatus.OK).build()));
+            }
+            return Mono.just(response);
+        });
+    }
+
+    public static ExchangeFilterFunction errorResponseHandler() {
+        return ExchangeFilterFunction.ofResponseProcessor(response -> {
+            if (response.statusCode().is4xxClientError()
+                    || response.statusCode().is5xxServerError()) {
+                return response.createException().flatMap(Mono::error);
+            }
+            return Mono.just(response);
+        });
+    }
+}

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/package-info.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/package-info.java
@@ -1,0 +1,1 @@
+package uk.gov.justice.laa.crime.assessmentservice.common;

--- a/crime-assessment-service/src/main/resources/application.yaml
+++ b/crime-assessment-service/src/main/resources/application.yaml
@@ -52,6 +52,21 @@ services:
     base-url: ${MAAT_API_BASE_URL}
     registrationId: maat-api
 
+resilience4j:
+  retry:
+    configs:
+      default:
+        max-attempts: 3
+        wait-duration: 2s
+        enableExponentialBackoff: true
+        exponentialBackoffMultiplier: 2
+        retry-exceptions:
+          - org.springframework.web.reactive.function.client.WebClientRequestException
+          - org.springframework.web.reactive.function.client.WebClientResponseException.BadGateway
+          - org.springframework.web.reactive.function.client.WebClientResponseException.TooManyRequests
+          - org.springframework.web.reactive.function.client.WebClientResponseException.ServiceUnavailable
+          - org.springframework.web.reactive.function.client.WebClientResponseException.GatewayTimeout
+
 springdoc:
   packagesToScan: uk.gov.justice.laa.crime.assessmentservice
   api-docs:

--- a/crime-assessment-service/src/main/resources/application.yaml
+++ b/crime-assessment-service/src/main/resources/application.yaml
@@ -20,6 +20,18 @@ spring:
     change-log: classpath:/db/changelog/db.changelog-master.yaml
     contexts: "!test"
 
+  security:
+    oauth2:
+      client:
+        provider:
+          maat-api:
+            token-uri: ${MAAT_API_OAUTH_URL}
+        registration:
+          maat-api:
+            client-id: ${MAAT_API_OAUTH_CLIENT_ID}
+            client-secret: ${MAAT_API_OAUTH_CLIENT_SECRET}
+            authorization-grant-type: client_credentials
+
 server:
   port: 8091
 
@@ -34,6 +46,11 @@ management:
     propagation:
       type: w3c,b3
     enabled: true
+
+services:
+  maat-api:
+    base-url: ${MAAT_API_BASE_URL}
+    registrationId: maat-api
 
 springdoc:
   packagesToScan: uk.gov.justice.laa.crime.assessmentservice

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/ModularityTests.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/ModularityTests.java
@@ -4,8 +4,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.modulith.core.ApplicationModules;
 import org.springframework.modulith.docs.Documenter;
 
+import com.tngtech.archunit.core.domain.JavaClass;
+
 class ModularityTests {
-    ApplicationModules modules = ApplicationModules.of(AssessmentServiceApplication.class);
+    ApplicationModules modules = ApplicationModules.of(
+                    AssessmentServiceApplication.class,
+                    JavaClass.Predicates.resideInAnyPackage("uk.gov.justice.laa.crime.assessmentservice.common.."))
+            .verify();
 
     @Test
     void verifiesModularStructure() {

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/filter/Resilience4jRetryFilterTest.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/filter/Resilience4jRetryFilterTest.java
@@ -1,0 +1,218 @@
+package uk.gov.justice.laa.crime.assessmentservice.filter;
+
+import static org.mockito.Mockito.when;
+
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
+import io.github.resilience4j.retry.RetryRegistry;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+import uk.gov.justice.laa.crime.assessmentservice.common.filter.Resilience4jRetryFilter;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.LinkedList;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(SoftAssertionsExtension.class)
+class Resilience4jRetryFilterTest {
+
+    @InjectSoftAssertions
+    private SoftAssertions softly;
+
+    @Mock
+    private ExchangeFunction exchangeFunction;
+
+    private static final int NUM_RETRIES = 3;
+    private static RetryRegistry retryRegistry;
+    public static final String DEFAULT_CONFIG_NAME = "default";
+    private static final URI DEFAULT_URL = URI.create("https://example.com");
+
+    @BeforeEach
+    void setupConfiguration() {
+        RetryConfig retryConfig = RetryConfig.custom()
+                .maxAttempts(NUM_RETRIES)
+                .retryExceptions(
+                        WebClientRequestException.class,
+                        WebClientResponseException.BadGateway.class,
+                        WebClientResponseException.TooManyRequests.class,
+                        WebClientResponseException.NotFound.class)
+                .failAfterMaxAttempts(true)
+                .build();
+        retryRegistry = RetryRegistry.of(retryConfig);
+    }
+
+    @Test
+    void givenRetriesExhausted_whenRetryFilterIsInvoked_thenFinalExceptionIsThrown() {
+        ClientRequest request =
+                ClientRequest.create(HttpMethod.GET, DEFAULT_URL).build();
+        LinkedList<RuntimeException> errors = new LinkedList<>(Arrays.asList(
+                WebClientTestUtils.getWebClientResponseException(HttpStatus.NOT_FOUND),
+                WebClientTestUtils.getWebClientResponseException(HttpStatus.TOO_MANY_REQUESTS),
+                WebClientTestUtils.getWebClientResponseException(HttpStatus.BAD_GATEWAY)));
+        Mono<ClientResponse> errorMono = getClientResponseMono(errors);
+
+        when(exchangeFunction.exchange(request)).thenReturn(errorMono);
+
+        Mono<ClientResponse> response =
+                new Resilience4jRetryFilter(retryRegistry, DEFAULT_CONFIG_NAME).filter(request, exchangeFunction);
+
+        softly.assertThatThrownBy(response::block)
+                .isInstanceOf(WebClientResponseException.BadGateway.class)
+                .hasMessageContaining("502 Bad Gateway");
+
+        verifyCorrectNumberOfCalls(NUM_RETRIES, DEFAULT_CONFIG_NAME);
+        softly.assertAll();
+    }
+
+    @Test
+    void givenSuccessfulResponseWithoutRetry_whenRetryFilterIsInvoked_thenOkResponseIsReturned() {
+        ClientRequest request =
+                ClientRequest.create(HttpMethod.GET, DEFAULT_URL).build();
+        Mono<ClientResponse> responseMono =
+                Mono.just(ClientResponse.create(HttpStatus.OK).build());
+
+        when(exchangeFunction.exchange(request)).thenReturn(responseMono);
+
+        Mono<ClientResponse> clientResponse =
+                new Resilience4jRetryFilter(retryRegistry, DEFAULT_CONFIG_NAME).filter(request, exchangeFunction);
+
+        ClientResponse response = clientResponse.block();
+
+        verifyCorrectNumberOfCalls(1, DEFAULT_CONFIG_NAME);
+        softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK);
+        softly.assertAll();
+    }
+
+    @Test
+    void givenSuccessfulResponseFollowingRetry_whenRetryFilterIsInvoked_thenOkResponseIsReturned() {
+        ClientRequest request =
+                ClientRequest.create(HttpMethod.GET, DEFAULT_URL).build();
+        LinkedList<RuntimeException> errors = new LinkedList<>(Arrays.asList(
+                WebClientTestUtils.getWebClientResponseException(HttpStatus.TOO_MANY_REQUESTS),
+                WebClientTestUtils.getWebClientResponseException(HttpStatus.BAD_GATEWAY)));
+
+        Mono<ClientResponse> responseMono = getClientResponseMono(errors);
+
+        when(exchangeFunction.exchange(request)).thenReturn(responseMono);
+
+        Mono<ClientResponse> clientResponse =
+                new Resilience4jRetryFilter(retryRegistry, DEFAULT_CONFIG_NAME).filter(request, exchangeFunction);
+
+        ClientResponse response = clientResponse.block();
+
+        verifyCorrectNumberOfCalls(NUM_RETRIES, DEFAULT_CONFIG_NAME);
+        softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK);
+        softly.assertAll();
+    }
+
+    private void verifyCorrectNumberOfCalls(int numRetries, String configName) {
+        Retry retry = retryRegistry.retry(configName);
+        long numberOfTotalCalls = retry.getMetrics().getNumberOfTotalCalls();
+        softly.assertThat(numberOfTotalCalls).isEqualTo(numRetries);
+    }
+
+    @Test
+    void givenUnRetryableException_whenRetryFilterIsInvoked_thenNoRetriesAreAttempted() {
+        ClientRequest request =
+                ClientRequest.create(HttpMethod.GET, DEFAULT_URL).build();
+
+        when(exchangeFunction.exchange(request))
+                .thenReturn(Mono.error(WebClientTestUtils.getWebClientResponseException(HttpStatus.UNAUTHORIZED)));
+
+        Mono<ClientResponse> response =
+                new Resilience4jRetryFilter(retryRegistry, DEFAULT_CONFIG_NAME).filter(request, exchangeFunction);
+
+        softly.assertThatThrownBy(response::block)
+                .isInstanceOf(WebClientResponseException.class)
+                .hasMessageContaining("401 Unauthorized");
+
+        verifyCorrectNumberOfCalls(1, DEFAULT_CONFIG_NAME);
+        softly.assertAll();
+    }
+
+    @Test
+    void givenOverrideConfiguration_whenRetryFilterIsInvoked_thenCorrectConfigurationIsApplied() {
+        RetryConfig retryConfig = RetryConfig.custom()
+                .maxAttempts(2)
+                .retryExceptions(WebClientResponseException.Conflict.class)
+                .failAfterMaxAttempts(true)
+                .build();
+        retryRegistry.retry("override", retryConfig);
+
+        ClientRequest request =
+                ClientRequest.create(HttpMethod.GET, DEFAULT_URL).build();
+
+        LinkedList<RuntimeException> errors = new LinkedList<>(Arrays.asList(
+                WebClientTestUtils.getWebClientResponseException(HttpStatus.CONFLICT),
+                WebClientTestUtils.getWebClientResponseException(HttpStatus.CONFLICT),
+                WebClientTestUtils.getWebClientResponseException(HttpStatus.CONFLICT)));
+
+        Mono<ClientResponse> errorMono = getClientResponseMono(errors);
+
+        when(exchangeFunction.exchange(request)).thenReturn(errorMono);
+
+        Mono<ClientResponse> response =
+                new Resilience4jRetryFilter(retryRegistry, "override").filter(request, exchangeFunction);
+
+        softly.assertThatThrownBy(response::block)
+                .isInstanceOf(WebClientResponseException.Conflict.class)
+                .hasMessageContaining("409 Conflict");
+
+        verifyCorrectNumberOfCalls(2, "override");
+        softly.assertAll();
+    }
+
+    @Test
+    void givenMissingOverrideConfiguration_whenRetryFilterIsInvoked_thenDefaultConfigurationIsApplied() {
+        ClientRequest request =
+                ClientRequest.create(HttpMethod.GET, DEFAULT_URL).build();
+
+        LinkedList<RuntimeException> errors = new LinkedList<>(Arrays.asList(
+                WebClientTestUtils.getWebClientResponseException(HttpStatus.BAD_GATEWAY),
+                WebClientTestUtils.getWebClientResponseException(HttpStatus.CONFLICT),
+                WebClientTestUtils.getWebClientResponseException(HttpStatus.TOO_MANY_REQUESTS)));
+
+        Mono<ClientResponse> errorMono = getClientResponseMono(errors);
+
+        when(exchangeFunction.exchange(request)).thenReturn(errorMono);
+
+        Mono<ClientResponse> response =
+                new Resilience4jRetryFilter(retryRegistry, "override").filter(request, exchangeFunction);
+
+        softly.assertThatThrownBy(response::block)
+                .isInstanceOf(WebClientResponseException.Conflict.class)
+                .hasMessageContaining("409 Conflict");
+
+        verifyCorrectNumberOfCalls(2, DEFAULT_CONFIG_NAME);
+        softly.assertAll();
+    }
+
+    private static Mono<ClientResponse> getClientResponseMono(LinkedList<RuntimeException> errors) {
+        return Mono.defer(() -> {
+            if (errors.isEmpty()) {
+                return Mono.just(ClientResponse.create(HttpStatus.OK).build());
+            }
+            Throwable error = errors.pop();
+            log.info("Simulating failure: {}", error.getClass().getSimpleName());
+            return Mono.error(error);
+        });
+    }
+}

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/filter/WebClientFiltersTest.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/filter/WebClientFiltersTest.java
@@ -1,0 +1,126 @@
+package uk.gov.justice.laa.crime.assessmentservice.filter;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import reactor.core.publisher.Mono;
+import uk.gov.justice.laa.crime.assessmentservice.common.filter.WebClientFilters;
+
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+class WebClientFiltersTest {
+
+    public static final ClientRequest CLIENT_REQUEST = ClientRequest.create(
+                    HttpMethod.GET, URI.create("https://example.com"))
+            .build();
+
+    @Test
+    void givenRequestWithHeaders_whenLogRequestHeadersFilterApplied_thenResponseIsPassedThrough() {
+        // given
+        ClientResponse dummyResponse = ClientResponse.create(HttpStatus.OK).build();
+
+        // Use an AtomicReference to capture the request passed along the filter chain.
+        AtomicReference<ClientRequest> capturedRequest = new AtomicReference<>();
+
+        // when
+        Mono<ClientResponse> result = WebClientFilters.logRequestHeaders().filter(CLIENT_REQUEST, req -> {
+            capturedRequest.set(req);
+            return Mono.just(dummyResponse);
+        });
+        ClientResponse response = result.block();
+
+        // then
+        assertThat(capturedRequest.get()).isEqualTo(CLIENT_REQUEST);
+        // Also verify that the response is passed through unchanged.
+        assertThat(response).isNotNull();
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void givenClientResponse_whenLogResponseFilterApplied_thenResponseIsUnchanged() {
+        // given
+        ClientResponse response = ClientResponse.create(HttpStatus.OK)
+                .header("X-Test", "headerValue")
+                .build();
+
+        // when
+        Mono<ClientResponse> result = WebClientFilters.logResponse().filter(CLIENT_REQUEST, req -> Mono.just(response));
+        ClientResponse filteredResponse = result.block();
+
+        // then
+        assertThat(filteredResponse).isNotNull();
+        assertThat(filteredResponse.statusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void givenSuccessResponse_whenErrorResponseHandlerApplied_thenResponseIsPassedThrough() {
+        // given
+        ClientResponse successResponse = ClientResponse.create(HttpStatus.OK).build();
+
+        // when
+        Mono<ClientResponse> result =
+                WebClientFilters.errorResponseHandler().filter(CLIENT_REQUEST, req -> Mono.just(successResponse));
+        ClientResponse filteredResponse = result.block();
+
+        // then
+        assertThat(filteredResponse).isNotNull();
+        assertThat(filteredResponse.statusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {400, 500})
+    void givenErrorResponse_whenErrorResponseHandlerApplied_thenThrowsWebClientResponseException(int statusCode) {
+        // given
+        ClientResponse errorResponse =
+                ClientResponse.create(HttpStatus.valueOf(statusCode)).build();
+        // when
+        Mono<ClientResponse> result =
+                WebClientFilters.errorResponseHandler().filter(CLIENT_REQUEST, req -> Mono.just(errorResponse));
+
+        // then
+        assertThatThrownBy(result::block).isInstanceOf(WebClientResponseException.class);
+    }
+
+    @Test
+    void givenNotFoundResponse_whenHandleNotFoundResponseApplied_thenReturnsSyntheticResponse() {
+        // given
+        ClientResponse notFoundResponse = ClientResponse.create(HttpStatus.NOT_FOUND)
+                .header("X-Test", "value")
+                .build();
+
+        // when
+        Mono<ClientResponse> result =
+                WebClientFilters.handleNotFoundResponse().filter(CLIENT_REQUEST, req -> Mono.just(notFoundResponse));
+        ClientResponse syntheticResponse = result.block();
+
+        // then
+        assertThat(syntheticResponse).isNotNull();
+        assertThat(syntheticResponse.statusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void givenNonNotFoundResponse_whenHandleNotFoundResponseApplied_thenResponseIsUnchanged() {
+        // given
+        ClientResponse errorResponse =
+                ClientResponse.create(HttpStatus.BAD_REQUEST).build();
+
+        // when
+        Mono<ClientResponse> result =
+                WebClientFilters.handleNotFoundResponse().filter(CLIENT_REQUEST, req -> Mono.just(errorResponse));
+        ClientResponse response = result.block();
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+}

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/filter/WebClientTestUtils.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/filter/WebClientTestUtils.java
@@ -1,0 +1,13 @@
+package uk.gov.justice.laa.crime.assessmentservice.filter;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+public class WebClientTestUtils {
+
+    public static WebClientResponseException getWebClientResponseException(HttpStatus status) {
+        return WebClientResponseException.create(
+                status.value(), status.getReasonPhrase(), new HttpHeaders(), new byte[0], null);
+    }
+}

--- a/crime-assessment-service/src/test/resources/application.yaml
+++ b/crime-assessment-service/src/test/resources/application.yaml
@@ -25,3 +25,8 @@ logging:
     root: INFO
     liquibase: DEBUG
     org.springframework.liquibase: DEBUG
+
+services:
+  maat-api:
+    base-url: http://localhost:${wiremock.server.port}
+    registrationId: maat-api

--- a/crime-assessment-service/src/test/resources/application.yaml
+++ b/crime-assessment-service/src/test/resources/application.yaml
@@ -30,3 +30,18 @@ services:
   maat-api:
     base-url: http://localhost:${wiremock.server.port}
     registrationId: maat-api
+
+resilience4j:
+  retry:
+    configs:
+      default:
+        max-attempts: 3
+        wait-duration: 2s
+        enableExponentialBackoff: true
+        exponentialBackoffMultiplier: 2
+        retry-exceptions:
+          - org.springframework.web.reactive.function.client.WebClientRequestException
+          - org.springframework.web.reactive.function.client.WebClientResponseException.BadGateway
+          - org.springframework.web.reactive.function.client.WebClientResponseException.TooManyRequests
+          - org.springframework.web.reactive.function.client.WebClientResponseException.ServiceUnavailable
+          - org.springframework.web.reactive.function.client.WebClientResponseException.GatewayTimeout

--- a/helm_deploy/crime-assessment-service/templates/_environment.tpl
+++ b/helm_deploy/crime-assessment-service/templates/_environment.tpl
@@ -6,6 +6,10 @@ Environment variables for service containers
 env:
   - name: AWS_REGION
     value: {{ .Values.aws_region }}
+  - name: MAAT_API_BASE_URL
+    value: {{ .Values.maatApi.baseUrl }}
+  - name: MAAT_API_OAUTH_URL
+    value: {{ .Values.maatApi.oauthUrl }}
   - name: SENTRY_DSN
     valueFrom:
       secretKeyRef:
@@ -38,4 +42,15 @@ env:
         secretKeyRef:
             name: crime-assessment-service-env-variables
             key: DATASOURCE_DBNAME
+  - name: MAAT_API_OAUTH_CLIENT_ID
+    valueFrom:
+        secretKeyRef:
+            name: crime-assessment-service-env-variables
+            key: MAAT_API_OAUTH_CLIENT_ID
+  - name: MAAT_API_OAUTH_CLIENT_SECRET
+    valueFrom:
+        secretKeyRef:
+            name: crime-assessment-service-env-variables
+            key: MAAT_API_OAUTH_CLIENT_SECRET
+
 {{- end -}}

--- a/helm_deploy/crime-assessment-service/values-dev.yaml
+++ b/helm_deploy/crime-assessment-service/values-dev.yaml
@@ -30,6 +30,10 @@ service:
   # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
   port: 8091
 
+maatApi:
+  baseUrl: https://laa-maat-data-api-dev.apps.live.cloud-platform.service.justice.gov.uk/api/internal/v1/assessment
+  oauthUrl: https://maat-api-dev.auth.eu-west-2.amazoncognito.com/oauth2/token
+
 # TODO ingress config
 ingress:
   enabled: true

--- a/helm_deploy/crime-assessment-service/values-prod.yaml
+++ b/helm_deploy/crime-assessment-service/values-prod.yaml
@@ -30,6 +30,10 @@ service:
   # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
   port: 8091
 
+maatApi:
+  baseUrl: https://laa-maat-data-api-prod.apps.live.cloud-platform.service.justice.gov.uk/api/internal/v1/assessment
+  oauthUrl: https://maat-api-prod.auth.eu-west-2.amazoncognito.com/oauth2/token
+
 # TODO ingress config
 ingress:
   enabled: true

--- a/helm_deploy/crime-assessment-service/values-test.yaml
+++ b/helm_deploy/crime-assessment-service/values-test.yaml
@@ -30,6 +30,10 @@ service:
   # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
   port: 8091
 
+maatApi:
+  baseUrl: https://laa-maat-data-api-test.apps.live.cloud-platform.service.justice.gov.uk/api/internal/v1/assessment
+  oauthUrl: https://maat-api-test.auth.eu-west-2.amazoncognito.com/oauth2/token
+
 # TODO ingress config
 ingress:
   enabled: true

--- a/helm_deploy/crime-assessment-service/values-uat.yaml
+++ b/helm_deploy/crime-assessment-service/values-uat.yaml
@@ -30,6 +30,10 @@ service:
   # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
   port: 8091
 
+maatApi:
+  baseUrl: https://laa-maat-data-api-uat.apps.live.cloud-platform.service.justice.gov.uk/api/internal/v1/assessment
+  oauthUrl: https://maat-api-uat.auth.eu-west-2.amazoncognito.com/oauth2/token
+
 # TODO ingress config
 ingress:
   enabled: true


### PR DESCRIPTION
This PR adds a new web client for interacting with MAAT API, defining a method to interact with the endpoint for getting an IoJ Appeal. The return type for this method has not been fully implemented but this is beyond the scope of the current work - it is simply there to act as a way to test our connection to MAAT API.

This PR also adds supporting classes and configuration to the service, including Resilience4j and OAuth configuration for interacting with MAAT API. The web client itself is defined in a new module `common`, which has been excluded from the application module inspection as it is really a common set of classes to be used across the modules of the service.

Successfully tested making a request to find IoJ Appeals endpoint of MAAT API through the client introduced in this PR.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1860)
