### PR TITLE
[LCAM-1876] Rename legacy_case_id to legacy_application_id in DB Schema

### DIFF
--- a/crime-assessment-service/src/main/resources/db/changelog/changeset/09-alter-ioj-appeal-table.sql
+++ b/crime-assessment-service/src/main/resources/db/changelog/changeset/09-alter-ioj-appeal-table.sql
@@ -1,0 +1,3 @@
+--liquibase formatted sql
+--changeset jhunt:09-alter-ioj-appeal-table.sql
+ALTER TABLE ioj_appeal.ioj_appeal RENAME COLUMN legacy_case_id TO legacy_application_id;   -- This references the rep_id/maat_id in the legacy system (which is used inconsistently).

--- a/crime-assessment-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/crime-assessment-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -15,3 +15,5 @@ databaseChangeLog:
       file: db/changelog/changeset/07-seed-test-ioj-appeal-data.sql
   - include:
       file: db/changelog/changeset/08-alter-ioj-appeal-table.sql
+  - include:
+      file: db/changelog/changeset/09-alter-ioj-appeal-table.sql


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1876)

Renamed legacy_case_id to legacy_application_id in DB Schema. As per the schema [here](https://github.com/ministryofjustice/laa-crime-commons/pull/218/files#diff-eaf705a3ef21b2fab8e4dbae864aba1757eb254be256282b2e0416adf7cc7990), we are going with legacyApplicationId for our naming of this field (which represents the rep_id/maat_id in the legacy systems) 
