### PR TITLE
Aligning service name across cloud platform and application

### DIFF
--- a/helm_deploy/crime-assessment-service/templates/_helpers.tpl
+++ b/helm_deploy/crime-assessment-service/templates/_helpers.tpl
@@ -69,7 +69,7 @@ Create ingress configuration
 {{- if $secret }}
 {{- $internalAllowlistSourceRange := $secret.data.INTERNAL_ALLOWLIST_SOURCE_RANGE | b64dec }}
 {{- if $internalAllowlistSourceRange }}
-nginx.ingress.kubernetes.io/whitelist-source-range: {{ $internalAllowlistSourceRange }}]
+nginx.ingress.kubernetes.io/whitelist-source-range: {{ $internalAllowlistSourceRange }}
 external-dns.alpha.kubernetes.io/set-identifier: {{ include "crime-assessment-service.fullname" . }}-{{ $.Values.ingress.environmentName}}-green
 {{- end }}
 {{- end }}

--- a/helm_deploy/crime-assessment-service/values-dev.yaml
+++ b/helm_deploy/crime-assessment-service/values-dev.yaml
@@ -21,7 +21,7 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: "laa-crime-assessment-service"
+  name: "crime-assessment-service"
 
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:

--- a/helm_deploy/crime-assessment-service/values-prod.yaml
+++ b/helm_deploy/crime-assessment-service/values-prod.yaml
@@ -21,7 +21,7 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: "laa-crime-assessment-service"
+  name: "crime-assessment-service"
 
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:

--- a/helm_deploy/crime-assessment-service/values-test.yaml
+++ b/helm_deploy/crime-assessment-service/values-test.yaml
@@ -21,7 +21,7 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: "laa-crime-assessment-service"
+  name: "crime-assessment-service"
 
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:

--- a/helm_deploy/crime-assessment-service/values-uat.yaml
+++ b/helm_deploy/crime-assessment-service/values-uat.yaml
@@ -21,7 +21,7 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: "laa-crime-assessment-service"
+  name: "crime-assessment-service"
 
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:


### PR DESCRIPTION
## What

Aligning service account name across application. ( Previously was mix between laa-crime-assessment-service and crime-assessment-service )
Aligning to the name of the helm charts, as seems the convention across services. 

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.
