### PR TITLE
Upgrade mod schemas and update IoJ Appeals schema usages

### DIFF
--- a/crime-assessment-service/build.gradle
+++ b/crime-assessment-service/build.gradle
@@ -20,7 +20,7 @@ def versions = [
     resilience4j                : "2.3.0",
     mapstruct                   : "1.6.3",
     crimeCommonsClasses         : "4.23.0",
-    crimeCommonsModSchemas      : "1.42.0"
+    crimeCommonsModSchemas      : "1.43.0"
 ]
 
 repositories {

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/entity/IojAppealEntity.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/entity/IojAppealEntity.java
@@ -49,6 +49,9 @@ public class IojAppealEntity {
     @Column(name = "assessor")
     private String appealAssessor;
 
+    @Column(name = "is_passed")
+    private boolean appealSuccessful;
+
     @Column(name = "decision_reason")
     private String decisionReason;
 
@@ -77,7 +80,4 @@ public class IojAppealEntity {
 
     @Column(name = "is_current")
     private boolean isCurrent;
-
-    @Column(name = "is_passed")
-    private boolean isPassed;
 }

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/mapper/IojAppealMapper.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/mapper/IojAppealMapper.java
@@ -8,7 +8,6 @@ import uk.gov.justice.laa.crime.common.model.ioj.IojAppeal;
 import org.mapstruct.Builder;
 import org.mapstruct.CollectionMappingStrategy;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.mapstruct.ReportingPolicy;
 
@@ -20,10 +19,8 @@ import org.mapstruct.ReportingPolicy;
         builder = @Builder(disableBuilder = true))
 public abstract class IojAppealMapper {
 
-    @Mapping(target = "appealSuccessful", source = "iojAppealEntity.passed")
     public abstract ApiGetIojAppealResponse mapEntityToDTO(IojAppealEntity iojAppealEntity);
 
-    @Mapping(target = "passed", source = "iojAppeal.appealSuccessful")
     public abstract IojAppealEntity mapAppealToEntity(IojAppeal iojAppeal);
 
     public IojAppealEntity mapCreateAppealRequestToEntity(ApiCreateIojAppealRequest request) {

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/IojAppealControllerTest.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/IojAppealControllerTest.java
@@ -89,7 +89,7 @@ class IojAppealControllerTest {
 
     @Test
     void givenEndpoint_whenCreateEndpointCalledWithValidRequest_thenOkResponseWithIds() throws Exception {
-        var request = TestDataBuilder.buildValidPopulatedCreateIoJAppealRequest();
+        var request = TestDataBuilder.buildValidPopulatedCreateIojAppealRequest();
         var mockEntity = TestDataBuilder.buildIojAppealEntity(true);
         mockEntity.setAppealId(UUID.randomUUID());
         when(iojAppealDualWriteService.createIojAppeal(request)).thenReturn(mockEntity);

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/IojAppealIntegrationTest.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/IojAppealIntegrationTest.java
@@ -118,12 +118,12 @@ class IojAppealIntegrationTest {
                 .andExpect(jsonPath("$.appealId")
                         .value(iojAppealEntity.getAppealId().toString()))
                 .andExpect(jsonPath("$.legacyAppealId").value(iojAppealEntity.getLegacyAppealId()))
-                .andExpect(jsonPath("$.receivedDate").value("2025-02-01T00:00:00"))
+                .andExpect(jsonPath("$.receivedDate").value("2025-02-01"))
                 .andExpect(jsonPath("$.appealAssessor").value(iojAppealEntity.getAppealAssessor()))
-                .andExpect(jsonPath("$.appealSuccessful").value(iojAppealEntity.isPassed()))
+                .andExpect(jsonPath("$.appealSuccessful").value(iojAppealEntity.isAppealSuccessful()))
                 .andExpect(jsonPath("$.decisionReason").value(IojAppealDecisionReason.DAMAGE_TO_REPUTATION.getCode()))
                 .andExpect(jsonPath("$.notes").value(iojAppealEntity.getNotes()))
-                .andExpect(jsonPath("$.decisionDate").value("2025-02-08T00:00:00"))
+                .andExpect(jsonPath("$.decisionDate").value("2025-02-08"))
                 .andExpect(jsonPath("$.caseManagementUnitId").value(iojAppealEntity.getCaseManagementUnitId()));
     }
 
@@ -139,12 +139,12 @@ class IojAppealIntegrationTest {
                 .andExpect(jsonPath("$.appealId")
                         .value(iojAppealEntity.getAppealId().toString()))
                 .andExpect(jsonPath("$.legacyAppealId").value(iojAppealEntity.getLegacyAppealId()))
-                .andExpect(jsonPath("$.receivedDate").value("2025-02-01T00:00:00"))
+                .andExpect(jsonPath("$.receivedDate").value("2025-02-01"))
                 .andExpect(jsonPath("$.appealAssessor").value(iojAppealEntity.getAppealAssessor()))
-                .andExpect(jsonPath("$.appealSuccessful").value(iojAppealEntity.isPassed()))
+                .andExpect(jsonPath("$.appealSuccessful").value(iojAppealEntity.isAppealSuccessful()))
                 .andExpect(jsonPath("$.decisionReason").value(IojAppealDecisionReason.DAMAGE_TO_REPUTATION.getCode()))
                 .andExpect(jsonPath("$.notes").value(iojAppealEntity.getNotes()))
-                .andExpect(jsonPath("$.decisionDate").value("2025-02-08T00:00:00"))
+                .andExpect(jsonPath("$.decisionDate").value("2025-02-08"))
                 .andExpect(jsonPath("$.caseManagementUnitId").value(iojAppealEntity.getCaseManagementUnitId()));
     }
 
@@ -153,13 +153,13 @@ class IojAppealIntegrationTest {
         ApiGetIojAppealResponse response = new ApiGetIojAppealResponse()
                 .withAppealId(APPEAL_ID.toString())
                 .withLegacyAppealId(223)
-                .withReceivedDate(LocalDate.of(2025, 2, 1).atStartOfDay())
+                .withReceivedDate(LocalDate.of(2025, 2, 1))
                 .withAppealReason(NewWorkReason.NEW)
                 .withAppealAssessor(IojAppealAssessor.CASEWORKER)
                 .withAppealSuccessful(true)
                 .withDecisionReason(IojAppealDecisionReason.DAMAGE_TO_REPUTATION)
                 .withNotes("Passing IoJ Appeal")
-                .withDecisionDate(LocalDate.of(2025, 2, 8).atStartOfDay())
+                .withDecisionDate(LocalDate.of(2025, 2, 8))
                 .withCaseManagementUnitId(44);
 
         wiremock.stubFor(get(urlEqualTo(MAAT_API_APPEAL_URL + "/223"))
@@ -173,19 +173,19 @@ class IojAppealIntegrationTest {
                 .andExpect(content().contentType(APPLICATION_JSON))
                 .andExpect(jsonPath("$.appealId").value(response.getAppealId()))
                 .andExpect(jsonPath("$.legacyAppealId").value(response.getLegacyAppealId()))
-                .andExpect(jsonPath("$.receivedDate").value("2025-02-01T00:00:00"))
+                .andExpect(jsonPath("$.receivedDate").value("2025-02-01"))
                 .andExpect(jsonPath("$.appealAssessor")
                         .value(response.getAppealAssessor().toString()))
                 .andExpect(jsonPath("$.appealSuccessful").value(response.getAppealSuccessful()))
                 .andExpect(jsonPath("$.decisionReason").value(IojAppealDecisionReason.DAMAGE_TO_REPUTATION.getCode()))
                 .andExpect(jsonPath("$.notes").value(response.getNotes()))
-                .andExpect(jsonPath("$.decisionDate").value("2025-02-08T00:00:00"))
+                .andExpect(jsonPath("$.decisionDate").value("2025-02-08"))
                 .andExpect(jsonPath("$.caseManagementUnitId").value(response.getCaseManagementUnitId()));
     }
 
     @Test
     void givenValidCreateRequest_whenCreateIsInvoked_thenSuccess() throws Exception {
-        var request = TestDataBuilder.buildValidPopulatedCreateIoJAppealRequest();
+        var request = TestDataBuilder.buildValidPopulatedCreateIojAppealRequest();
         var initialAppealCount = iojAppealRepository.count();
         var response = new ApiCreateIojAppealResponse().withLegacyAppealId(1001);
 
@@ -211,7 +211,7 @@ class IojAppealIntegrationTest {
 
     @Test
     void givenMaatFailure_whenCreateIsInvoked_thenNothingWritten() throws Exception {
-        var request = TestDataBuilder.buildValidPopulatedCreateIoJAppealRequest();
+        var request = TestDataBuilder.buildValidPopulatedCreateIojAppealRequest();
         var initialAppealCount = iojAppealRepository.count();
         wiremock.stubFor(post(urlEqualTo(MAAT_API_APPEAL_URL)).willReturn(WireMock.serverError()));
         mvc.perform(MockMvcRequestBuilders.post(ENDPOINT_URL)
@@ -226,7 +226,7 @@ class IojAppealIntegrationTest {
 
     @Test
     void givenUpdateFailure_whenCreateIsInvoked_thenAppealIsWritten() throws Exception {
-        var request = TestDataBuilder.buildValidPopulatedCreateIoJAppealRequest();
+        var request = TestDataBuilder.buildValidPopulatedCreateIojAppealRequest();
         var initialAppealCount = iojAppealRepository.count();
         var response = new ApiCreateIojAppealResponse().withLegacyAppealId(1001);
         doThrow(new RuntimeException("Test Exception")).when(iojAppealService).save(any(IojAppealEntity.class));

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/mapper/IoJAppealMapperTest.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/mapper/IoJAppealMapperTest.java
@@ -12,7 +12,7 @@ class IoJAppealMapperTest {
 
     @Test
     void whenCreateRequest_whenMapCreateAppealToEntity_thenAllFieldsMapped() {
-        var request = TestDataBuilder.buildValidPopulatedCreateIoJAppealRequest();
+        var request = TestDataBuilder.buildValidPopulatedCreateIojAppealRequest();
         var entity = iojAppealMapper.mapCreateAppealRequestToEntity(request);
         // check only nulls are known, non-mapped fields.
         assertThat(entity)

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/validator/ApiCreateIojAppealRequestValidatorTest.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/validator/ApiCreateIojAppealRequestValidatorTest.java
@@ -43,11 +43,13 @@ class ApiCreateIojAppealRequestValidatorTest {
 
     @Test
     void whenAppealAndMetaPresentButNotPopulated_thenAllMissingFieldValidationErrorsReturned() {
-        ApiCreateIojAppealRequest request = new ApiCreateIojAppealRequest();
-        request.setIojAppeal(new IojAppeal());
-        request.setIojAppealMetadata(new IojAppealMetadata());
+        ApiCreateIojAppealRequest request = new ApiCreateIojAppealRequest()
+                .withIojAppeal(new IojAppeal())
+                .withIojAppealMetadata(new IojAppealMetadata());
+
         int expectedErrorCount = 10; // 6 field validations on appeal, 4 on metadata.
         List<String> returnedErrorList = ApiCreateIojAppealRequestValidator.validateRequest(request);
+
         assertThat(returnedErrorList).hasSize(expectedErrorCount);
         assertThat(returnedErrorList.stream()
                         .filter(x -> x.contains(" is missing."))
@@ -74,7 +76,7 @@ class ApiCreateIojAppealRequestValidatorTest {
     @MethodSource("reasonAssessorCombinations")
     void whenIojAssessorAndReasonCombinationIsTested_thenErrorShouldSurfaceIfInvalidCombination(
             IojAppealAssessor assessor, NewWorkReason reason, boolean isValidCombination) {
-        var request = TestDataBuilder.buildValidPopulatedCreateIoJAppealRequest();
+        ApiCreateIojAppealRequest request = TestDataBuilder.buildValidPopulatedCreateIojAppealRequest();
         request.getIojAppeal().setAppealAssessor(assessor);
         request.getIojAppeal().setAppealReason(reason);
 
@@ -94,7 +96,7 @@ class ApiCreateIojAppealRequestValidatorTest {
             mode = EnumSource.Mode.EXCLUDE)
     void whenInvalidAppealReasonSelected_thenOneError(NewWorkReason reason) {
         // Judicial Review + Judge
-        var request = TestDataBuilder.buildValidPopulatedCreateIoJAppealRequest();
+        ApiCreateIojAppealRequest request = TestDataBuilder.buildValidPopulatedCreateIojAppealRequest();
         request.getIojAppeal().setAppealReason(reason);
 
         List<String> returnedErrorList = ApiCreateIojAppealRequestValidator.validateRequest(request);
@@ -104,9 +106,11 @@ class ApiCreateIojAppealRequestValidatorTest {
 
     @Test
     void whenValidButNoAssessor_thenOnlyMissingErrors() {
-        var request = TestDataBuilder.buildValidPopulatedCreateIoJAppealRequest();
+        ApiCreateIojAppealRequest request = TestDataBuilder.buildValidPopulatedCreateIojAppealRequest();
         request.getIojAppeal().setAppealAssessor(null);
+
         List<String> returnedErrorList = ApiCreateIojAppealRequestValidator.validateRequest(request);
+
         assertThat(returnedErrorList).hasSize(1);
         assertThat(returnedErrorList.getFirst()).isEqualTo(getExpectedMissingError(APPEAL_ASSESSOR.getName()));
     }
@@ -114,11 +118,12 @@ class ApiCreateIojAppealRequestValidatorTest {
     @ParameterizedTest
     @NullAndEmptySource // additional check to ensure validation works on empty strings and nulls
     void whenValidButNoUserSessionDetails_thenOnlyMissingErrors(String emptyOrNull) {
-        var request = TestDataBuilder.buildValidPopulatedCreateIoJAppealRequest();
+        ApiCreateIojAppealRequest request = TestDataBuilder.buildValidPopulatedCreateIojAppealRequest();
         request.getIojAppealMetadata().getUserSession().setUserName(emptyOrNull);
         request.getIojAppealMetadata().getUserSession().setSessionId(emptyOrNull);
 
         List<String> returnedErrorList = ApiCreateIojAppealRequestValidator.validateRequest(request);
+
         assertThat(returnedErrorList)
                 .hasSize(2)
                 .containsExactlyInAnyOrder(

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/utils/TestDataBuilder.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/utils/TestDataBuilder.java
@@ -11,21 +11,20 @@ import uk.gov.justice.laa.crime.enums.IojAppealDecisionReason;
 import uk.gov.justice.laa.crime.enums.NewWorkReason;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @UtilityClass
 public class TestDataBuilder {
 
-    public ApiCreateIojAppealRequest buildValidPopulatedCreateIoJAppealRequest() {
+    public ApiCreateIojAppealRequest buildValidPopulatedCreateIojAppealRequest() {
         ApiCreateIojAppealRequest request = new ApiCreateIojAppealRequest();
         var appeal = new IojAppeal();
         appeal.setAppealSuccessful(true);
         appeal.setAppealReason(NewWorkReason.JR);
         appeal.setAppealAssessor(IojAppealAssessor.JUDGE);
         appeal.setDecisionReason(IojAppealDecisionReason.INTERESTS_PERSON);
-        appeal.setReceivedDate(LocalDateTime.now());
-        appeal.setDecisionDate(LocalDateTime.now());
+        appeal.setReceivedDate(LocalDate.now());
+        appeal.setDecisionDate(LocalDate.now());
         appeal.setNotes("Notes are Here");
 
         var metaData = new IojAppealMetadata();
@@ -49,7 +48,7 @@ public class TestDataBuilder {
                 .receivedDate(LocalDate.of(2025, 2, 1))
                 .appealReason(NewWorkReason.NEW.getCode())
                 .appealAssessor(IojAppealAssessor.CASEWORKER.name())
-                .isPassed(true)
+                .appealSuccessful(true)
                 .decisionReason("DAMAGE_TO_REPUTATION")
                 .notes("Passing IoJ Appeal")
                 .decisionDate(LocalDate.of(2025, 2, 8))


### PR DESCRIPTION
This PR upgrades `crime-commons-mod-schemas` from version `1.40.0` to `1.43.0`, which introduces changes to the IoJ appeals schemas through type changes for date fields, the removal of the application id field and the refactoring of the appeal decision field from an enum to a boolean with the name appeal successful.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1904)
