### PR TITLE
LCAM-1900: Update MAAT API endpoint configuration

### DIFF
--- a/helm_deploy/crime-assessment-service/templates/service.yaml
+++ b/helm_deploy/crime-assessment-service/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: http
     - port: {{ .Values.actuator.port }}

--- a/helm_deploy/crime-assessment-service/values-dev.yaml
+++ b/helm_deploy/crime-assessment-service/values-dev.yaml
@@ -25,10 +25,9 @@ serviceAccount:
 
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
-  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
   type: ClusterIP
-  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
-  port: 8091
+  port: 80
+  targetPort: 8091
 
 maatApi:
   baseUrl: http://laa-maat-data-api.laa-maat-data-api-dev.svc.cluster.local:8090

--- a/helm_deploy/crime-assessment-service/values-dev.yaml
+++ b/helm_deploy/crime-assessment-service/values-dev.yaml
@@ -31,7 +31,7 @@ service:
   port: 8091
 
 maatApi:
-  baseUrl: https://laa-maat-data-api-dev.apps.live.cloud-platform.service.justice.gov.uk/api/internal/v1/assessment
+  baseUrl: http://laa-maat-data-api-dev.svc.cluster.local/api/internal/v1/assessment
   oauthUrl: https://maat-api-dev.auth.eu-west-2.amazoncognito.com/oauth2/token
 
 # TODO ingress config

--- a/helm_deploy/crime-assessment-service/values-dev.yaml
+++ b/helm_deploy/crime-assessment-service/values-dev.yaml
@@ -31,7 +31,7 @@ service:
   port: 8091
 
 maatApi:
-  baseUrl: http://laa-maat-data-api-dev.svc.cluster.local/api/internal/v1/assessment
+  baseUrl: http://laa-maat-data-api.laa-maat-data-api-dev.svc.cluster.local:8090
   oauthUrl: https://maat-api-dev.auth.eu-west-2.amazoncognito.com/oauth2/token
 
 # TODO ingress config

--- a/helm_deploy/crime-assessment-service/values-prod.yaml
+++ b/helm_deploy/crime-assessment-service/values-prod.yaml
@@ -31,7 +31,7 @@ service:
   port: 8091
 
 maatApi:
-  baseUrl: http://laa-maat-data-api-prod.svc.cluster.local/api/internal/v1/assessment
+  baseUrl: http://laa-maat-data-api.laa-maat-data-api-prod.svc.cluster.local:8090
   oauthUrl: https://maat-api-prod.auth.eu-west-2.amazoncognito.com/oauth2/token
 
 ingress:

--- a/helm_deploy/crime-assessment-service/values-prod.yaml
+++ b/helm_deploy/crime-assessment-service/values-prod.yaml
@@ -25,10 +25,9 @@ serviceAccount:
 
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
-  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
   type: ClusterIP
-  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
-  port: 8091
+  port: 80
+  targetPort: 8091
 
 maatApi:
   baseUrl: http://laa-maat-data-api.laa-maat-data-api-prod.svc.cluster.local:8090

--- a/helm_deploy/crime-assessment-service/values-prod.yaml
+++ b/helm_deploy/crime-assessment-service/values-prod.yaml
@@ -31,7 +31,7 @@ service:
   port: 8091
 
 maatApi:
-  baseUrl: https://laa-maat-data-api-prod.apps.live.cloud-platform.service.justice.gov.uk/api/internal/v1/assessment
+  baseUrl: http://laa-maat-data-api-prod.svc.cluster.local/api/internal/v1/assessment
   oauthUrl: https://maat-api-prod.auth.eu-west-2.amazoncognito.com/oauth2/token
 
 # TODO ingress config

--- a/helm_deploy/crime-assessment-service/values-prod.yaml
+++ b/helm_deploy/crime-assessment-service/values-prod.yaml
@@ -34,22 +34,8 @@ maatApi:
   baseUrl: http://laa-maat-data-api-prod.svc.cluster.local/api/internal/v1/assessment
   oauthUrl: https://maat-api-prod.auth.eu-west-2.amazoncognito.com/oauth2/token
 
-# TODO ingress config
 ingress:
-  enabled: true
-  environmentName: laa-crime-assessment-service-prod
-  className: default
-  annotations:
-    external-dns.alpha.kubernetes.io/aws-weight: "100"
-    nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-max-age: "300"
-  hosts:
-    - host: laa-crime-assessment-service-prod.apps.live.cloud-platform.service.justice.gov.uk
-      paths:
-        - path: /
-          pathType: "Prefix"
-  tls: []
-
+  enabled: false
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:

--- a/helm_deploy/crime-assessment-service/values-test.yaml
+++ b/helm_deploy/crime-assessment-service/values-test.yaml
@@ -31,7 +31,7 @@ service:
   port: 8091
 
 maatApi:
-  baseUrl: https://laa-maat-data-api-test.apps.live.cloud-platform.service.justice.gov.uk/api/internal/v1/assessment
+  baseUrl: http://laa-maat-data-api-test.svc.cluster.local/api/internal/v1/assessment
   oauthUrl: https://maat-api-test.auth.eu-west-2.amazoncognito.com/oauth2/token
 
 # TODO ingress config

--- a/helm_deploy/crime-assessment-service/values-test.yaml
+++ b/helm_deploy/crime-assessment-service/values-test.yaml
@@ -25,10 +25,9 @@ serviceAccount:
 
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
-  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
   type: ClusterIP
-  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
-  port: 8091
+  port: 80
+  targetPort: 8091
 
 maatApi:
   baseUrl: http://laa-maat-data-api.laa-maat-data-api-test.svc.cluster.local:8090

--- a/helm_deploy/crime-assessment-service/values-test.yaml
+++ b/helm_deploy/crime-assessment-service/values-test.yaml
@@ -31,7 +31,7 @@ service:
   port: 8091
 
 maatApi:
-  baseUrl: http://laa-maat-data-api-test.svc.cluster.local/api/internal/v1/assessment
+  baseUrl: http://laa-maat-data-api.laa-maat-data-api-test.svc.cluster.local:8090
   oauthUrl: https://maat-api-test.auth.eu-west-2.amazoncognito.com/oauth2/token
 
 # TODO ingress config

--- a/helm_deploy/crime-assessment-service/values-uat.yaml
+++ b/helm_deploy/crime-assessment-service/values-uat.yaml
@@ -31,7 +31,7 @@ service:
   port: 8091
 
 maatApi:
-  baseUrl: https://laa-maat-data-api-uat.apps.live.cloud-platform.service.justice.gov.uk/api/internal/v1/assessment
+  baseUrl: http://laa-maat-data-api-uat.svc.cluster.local/api/internal/v1/assessment
   oauthUrl: https://maat-api-uat.auth.eu-west-2.amazoncognito.com/oauth2/token
 
 # TODO ingress config

--- a/helm_deploy/crime-assessment-service/values-uat.yaml
+++ b/helm_deploy/crime-assessment-service/values-uat.yaml
@@ -31,7 +31,7 @@ service:
   port: 8091
 
 maatApi:
-  baseUrl: http://laa-maat-data-api-uat.svc.cluster.local/api/internal/v1/assessment
+  baseUrl: http://laa-maat-data-api.laa-maat-data-api-uat.svc.cluster.local:8090
   oauthUrl: https://maat-api-uat.auth.eu-west-2.amazoncognito.com/oauth2/token
 
 # TODO ingress config

--- a/helm_deploy/crime-assessment-service/values-uat.yaml
+++ b/helm_deploy/crime-assessment-service/values-uat.yaml
@@ -25,10 +25,9 @@ serviceAccount:
 
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
-  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
   type: ClusterIP
-  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
-  port: 8091
+  port: 80
+  targetPort: 8091
 
 maatApi:
   baseUrl: http://laa-maat-data-api.laa-maat-data-api-uat.svc.cluster.local:8090


### PR DESCRIPTION
This PR updates the MAAT API endpoint configuration to use the internal cluster endpoint rather than the external endpoint, keeping all requests within the cluster for both efficiency and security concerns. Unfortunately, the way MAAT API is currently set-up requires that requests coming in via this internal endpoint need to specify the port number, because that is the port which the Kubernetes service is set-up to listen to for incoming requests (this isn't a problem for existing services in prod that use MAAT API because they are currently all configured to use the external endpoint, but it will become a problem for them too as they also make the switch to internal requests).

This PR updates the service configuration for Kubernetes to align it with others such as the Evidence and Hardship services, listening on port 80 (`http`) and mapping to the target port of whatever the app is running on (for the Assessment Service, `8091`). Doing this means that we do not need to also specify the port for the Assessment Service when making calls from the Orchestration Service, again aligning to how the Orchestration Service calls all of the existing services when using the internal cluster endpoint.

This PR additionally disables the production ingress, as all requests to the service should be routed internally within the cluster.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1900)
