### PR TITLE
Fix Helm template ingress definition

### DIFF
--- a/helm_deploy/crime-assessment-service/templates/ingress.yaml
+++ b/helm_deploy/crime-assessment-service/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled -}}
 {{- $fullName := include "crime-assessment-service.fullname" . -}}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
@@ -61,3 +62,4 @@ spec:
                   number: {{ $.Values.actuator.port }}
           {{- end }}
     {{- end }}
+{{- end }}


### PR DESCRIPTION
This PR fixes the Helm template ingress definition to ensure that the ingress is only defined if the `ingress.enabled` flag is set to `true`.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1900)