### PR TITLE
LCAM-1923 - Create IoJ Appeal Rollback Logic

### DIFF
--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/client/MaatCourtDataApiClient.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/client/MaatCourtDataApiClient.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.crime.assessmentservice.common.client;
 
+import org.springframework.web.service.annotation.PatchExchange;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealRequest;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealResponse;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiGetIojAppealResponse;
@@ -17,4 +18,7 @@ public interface MaatCourtDataApiClient {
 
     @PostExchange("/api/internal/v2/assessment/ioj-appeals")
     ApiCreateIojAppealResponse createIojAppeal(@RequestBody ApiCreateIojAppealRequest request);
+
+    @PatchExchange("/api/internal/v2/assessment/ioj-appeals/rollback/{legacyAppealId}")
+    void rollbackIojAppeal(@PathVariable Integer legacyAppealId);
 }

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/client/MaatCourtDataApiClient.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/client/MaatCourtDataApiClient.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.laa.crime.assessmentservice.common.client;
 
-import org.springframework.web.service.annotation.PatchExchange;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealRequest;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealResponse;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiGetIojAppealResponse;
@@ -9,10 +8,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
+import org.springframework.web.service.annotation.PatchExchange;
 import org.springframework.web.service.annotation.PostExchange;
 
 @HttpExchange()
 public interface MaatCourtDataApiClient {
+
     @GetExchange("/api/internal/v2/assessment/ioj-appeals/{legacyAppealId}")
     ApiGetIojAppealResponse getIojAppeal(@PathVariable Integer legacyAppealId);
 

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/AssessmentRollbackException.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/AssessmentRollbackException.java
@@ -1,0 +1,8 @@
+package uk.gov.justice.laa.crime.assessmentservice.common.exception;
+
+public class AssessmentRollbackException extends RuntimeException {
+
+    public AssessmentRollbackException(String exceptionMessage) {
+        super(exceptionMessage);
+    }
+}

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/AssessmentServiceException.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/AssessmentServiceException.java
@@ -7,5 +7,4 @@ public class AssessmentServiceException extends RuntimeException {
     public AssessmentServiceException(String exceptionMessage) {
         this.exceptionMessage = exceptionMessage;
     }
-
 }

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/AssessmentServiceException.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/AssessmentServiceException.java
@@ -2,8 +2,10 @@ package uk.gov.justice.laa.crime.assessmentservice.common.exception;
 
 public class AssessmentServiceException extends RuntimeException {
 
-    public AssessmentServiceException() {
+    private final String exceptionMessage;
 
+    public AssessmentServiceException(String exceptionMessage) {
+        this.exceptionMessage = exceptionMessage;
     }
 
 }

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/AssessmentServiceException.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/AssessmentServiceException.java
@@ -1,8 +1,0 @@
-package uk.gov.justice.laa.crime.assessmentservice.common.exception;
-
-public class AssessmentServiceException extends RuntimeException {
-
-    public AssessmentServiceException(String exceptionMessage) {
-        super(exceptionMessage);
-    }
-}

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/AssessmentServiceException.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/AssessmentServiceException.java
@@ -2,9 +2,7 @@ package uk.gov.justice.laa.crime.assessmentservice.common.exception;
 
 public class AssessmentServiceException extends RuntimeException {
 
-    private final String exceptionMessage;
-
     public AssessmentServiceException(String exceptionMessage) {
-        this.exceptionMessage = exceptionMessage;
+        super(exceptionMessage);
     }
 }

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/AssessmentServiceException.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/AssessmentServiceException.java
@@ -1,0 +1,9 @@
+package uk.gov.justice.laa.crime.assessmentservice.common.exception;
+
+public class AssessmentServiceException extends RuntimeException {
+
+    public AssessmentServiceException() {
+
+    }
+
+}

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/DefaultExceptionHandler.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/DefaultExceptionHandler.java
@@ -22,13 +22,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class DefaultExceptionHandler {
+
     private final ObjectMapper mapper;
 
     @ExceptionHandler(WebClientResponseException.class)
     public ResponseEntity<ErrorDTO> onRuntimeException(WebClientResponseException exception) {
         String errorMessage;
         try {
-            ErrorDTO errorDTO = mapper.readValue(exception.getResponseBodyAsString(), ErrorDTO.class);
+            ErrorDTO errorDTO = mapper.readValue(exception.getResponseBodyAsString(),
+                ErrorDTO.class);
             errorMessage = errorDTO.getMessage();
         } catch (IOException ex) {
             log.warn("Unable to read the ErrorDTO from WebClientResponseException", ex);
@@ -48,14 +50,15 @@ public class DefaultExceptionHandler {
     }
 
     @ExceptionHandler(AssessmentServiceException.class)
-    public ResponseEntity<ProblemDetail> handleAssessmentServiceException(AssessmentServiceException exc) {
-        // TODO: Need a new error response builder for this type in exception utils????
-        // return CrimeValidationExceptionUtil.buildValidationErrorResponse(new ArrayList<>(ex.getExceptionMessage()));
+    public ResponseEntity<ErrorDTO> handleAssessmentServiceException(
+        AssessmentServiceException exception) {
+        return buildErrorResponse(HttpStatusCode.valueOf(555), exception.getMessage());
     }
 
-    private static ResponseEntity<ErrorDTO> buildErrorResponse(HttpStatusCode status, String message) {
+    private static ResponseEntity<ErrorDTO> buildErrorResponse(HttpStatusCode status,
+        String message) {
         log.error("Exception Occurred. Status - {}, Detail - {}, TraceId - {}", status, message);
         return new ResponseEntity<>(
-                ErrorDTO.builder().code(status.toString()).message(message).build(), status);
+            ErrorDTO.builder().code(status.toString()).message(message).build(), status);
     }
 }

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/DefaultExceptionHandler.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/DefaultExceptionHandler.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.crime.assessmentservice.common.exception;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ProblemDetail;
 import uk.gov.justice.laa.crime.dto.ErrorDTO;
 import uk.gov.justice.laa.crime.exception.ValidationException;
 
@@ -44,6 +45,12 @@ public class DefaultExceptionHandler {
     @ExceptionHandler(ValidationException.class)
     public ResponseEntity<ErrorDTO> handleValidationException(ValidationException exception) {
         return buildErrorResponse(HttpStatus.BAD_REQUEST, exception.getMessage());
+    }
+
+    @ExceptionHandler(AssessmentServiceException.class)
+    public ResponseEntity<ProblemDetail> handleAssessmentServiceException(AssessmentServiceException exc) {
+        // TODO: Need a new error response builder for this type in exception utils????
+        // return CrimeValidationExceptionUtil.buildValidationErrorResponse(new ArrayList<>(ex.getExceptionMessage()));
     }
 
     private static ResponseEntity<ErrorDTO> buildErrorResponse(HttpStatusCode status, String message) {

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/DefaultExceptionHandler.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/DefaultExceptionHandler.java
@@ -47,8 +47,8 @@ public class DefaultExceptionHandler {
         return buildErrorResponse(HttpStatus.BAD_REQUEST, exception.getMessage());
     }
 
-    @ExceptionHandler(AssessmentServiceException.class)
-    public ResponseEntity<ErrorDTO> handleAssessmentServiceException(AssessmentServiceException exception) {
+    @ExceptionHandler(AssessmentRollbackException.class)
+    public ResponseEntity<ErrorDTO> handleAssessmentRollbackException(AssessmentRollbackException exception) {
         return buildErrorResponse(HttpStatusCode.valueOf(555), exception.getMessage());
     }
 

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/DefaultExceptionHandler.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/common/exception/DefaultExceptionHandler.java
@@ -2,7 +2,6 @@ package uk.gov.justice.laa.crime.assessmentservice.common.exception;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ProblemDetail;
 import uk.gov.justice.laa.crime.dto.ErrorDTO;
 import uk.gov.justice.laa.crime.exception.ValidationException;
 
@@ -29,8 +28,7 @@ public class DefaultExceptionHandler {
     public ResponseEntity<ErrorDTO> onRuntimeException(WebClientResponseException exception) {
         String errorMessage;
         try {
-            ErrorDTO errorDTO = mapper.readValue(exception.getResponseBodyAsString(),
-                ErrorDTO.class);
+            ErrorDTO errorDTO = mapper.readValue(exception.getResponseBodyAsString(), ErrorDTO.class);
             errorMessage = errorDTO.getMessage();
         } catch (IOException ex) {
             log.warn("Unable to read the ErrorDTO from WebClientResponseException", ex);
@@ -50,15 +48,13 @@ public class DefaultExceptionHandler {
     }
 
     @ExceptionHandler(AssessmentServiceException.class)
-    public ResponseEntity<ErrorDTO> handleAssessmentServiceException(
-        AssessmentServiceException exception) {
+    public ResponseEntity<ErrorDTO> handleAssessmentServiceException(AssessmentServiceException exception) {
         return buildErrorResponse(HttpStatusCode.valueOf(555), exception.getMessage());
     }
 
-    private static ResponseEntity<ErrorDTO> buildErrorResponse(HttpStatusCode status,
-        String message) {
+    private static ResponseEntity<ErrorDTO> buildErrorResponse(HttpStatusCode status, String message) {
         log.error("Exception Occurred. Status - {}, Detail - {}, TraceId - {}", status, message);
         return new ResponseEntity<>(
-            ErrorDTO.builder().code(status.toString()).message(message).build(), status);
+                ErrorDTO.builder().code(status.toString()).message(message).build(), status);
     }
 }

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/controller/IojAppealController.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/controller/IojAppealController.java
@@ -62,15 +62,11 @@ public class IojAppealController implements IojAppealApi {
             throw new CrimeValidationException(validationErrors);
         }
 
-        try {
-            IojAppealEntity appealEntity = iojAppealDualWriteService.createIojAppeal(request);
+        IojAppealEntity appealEntity = iojAppealDualWriteService.createIojAppeal(request);
 
-            ApiCreateIojAppealResponse response = new ApiCreateIojAppealResponse()
-                .withAppealId(appealEntity.getAppealId().toString())
-                .withLegacyAppealId(appealEntity.getLegacyAppealId());
-            return ResponseEntity.ok(response);
-        } catch(AssessmentServiceException exc) {
-            return ResponseEntity.status(555).build();
-        }
+        ApiCreateIojAppealResponse response = new ApiCreateIojAppealResponse()
+            .withAppealId(appealEntity.getAppealId().toString())
+            .withLegacyAppealId(appealEntity.getLegacyAppealId());
+        return ResponseEntity.ok(response);
     }
 }

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/controller/IojAppealController.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/controller/IojAppealController.java
@@ -3,7 +3,6 @@ package uk.gov.justice.laa.crime.assessmentservice.iojappeal.controller;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import uk.gov.justice.laa.crime.assessmentservice.common.exception.AssessmentServiceException;
 import uk.gov.justice.laa.crime.assessmentservice.common.exception.CrimeValidationException;
 import uk.gov.justice.laa.crime.assessmentservice.iojappeal.entity.IojAppealEntity;
 import uk.gov.justice.laa.crime.assessmentservice.iojappeal.service.IojAppealDualWriteService;
@@ -65,8 +64,8 @@ public class IojAppealController implements IojAppealApi {
         IojAppealEntity appealEntity = iojAppealDualWriteService.createIojAppeal(request);
 
         ApiCreateIojAppealResponse response = new ApiCreateIojAppealResponse()
-            .withAppealId(appealEntity.getAppealId().toString())
-            .withLegacyAppealId(appealEntity.getLegacyAppealId());
+                .withAppealId(appealEntity.getAppealId().toString())
+                .withLegacyAppealId(appealEntity.getLegacyAppealId());
         return ResponseEntity.ok(response);
     }
 }

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/IojAppealDualWriteService.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/IojAppealDualWriteService.java
@@ -28,13 +28,11 @@ public class IojAppealDualWriteService {
             appealEntity.setLegacyAppealId(legacyAppealId);
             iojAppealService.save(appealEntity);
         } catch (Exception exc) {
-            log.error("Error encountered linking appealId %d to legacyAppealId %d",
-                appealEntity.getAppealId(), legacyAppealId);
             legacyIojAppealService.rollback(legacyAppealId);
             iojAppealService.delete(appealEntity);
             throw new AssessmentServiceException(String.format(
-                "Exception encountered during linking process, creation has been rolled back: %s",
-                exc.getMessage()));
+                "Error linking appealId %s to legacyAppealId %d, creation has been rolled back: %s",
+                appealEntity.getAppealId().toString(), legacyAppealId, exc.getMessage()));
         }
 
         return appealEntity;

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/IojAppealDualWriteService.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/IojAppealDualWriteService.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.crime.assessmentservice.iojappeal.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import uk.gov.justice.laa.crime.assessmentservice.common.exception.AssessmentServiceException;
 import uk.gov.justice.laa.crime.assessmentservice.iojappeal.entity.IojAppealEntity;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealRequest;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealResponse;
@@ -20,15 +21,15 @@ public class IojAppealDualWriteService {
     public IojAppealEntity createIojAppeal(ApiCreateIojAppealRequest request) {
         IojAppealEntity appealEntity = iojAppealService.create(request);
         ApiCreateIojAppealResponse legacyAppeal = legacyIojAppealService.create(request);
-        // set the legacy id on the new DB entity, and save.
-        appealEntity.setLegacyAppealId(legacyAppeal.getLegacyAppealId());
-        // TODO: Awaiting further rollback work here.
-        //  If error below, should we rollback the above?
-        //  If so, need MAAT endpoint.
+
         try {
+            appealEntity.setLegacyAppealId(legacyAppeal.getLegacyAppealId());
             iojAppealService.save(appealEntity);
         } catch (Exception e) {
             log.error("Exception was hit during the second DB hit. This needs investigating.");
+            legacyIojAppealService.rollback(legacyAppeal.getLegacyAppealId());
+            iojAppealService.delete(appealEntity);
+            throw new AssessmentServiceException("bla");
         }
         return appealEntity;
     }

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/IojAppealDualWriteService.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/IojAppealDualWriteService.java
@@ -31,8 +31,8 @@ public class IojAppealDualWriteService {
             legacyIojAppealService.rollback(legacyAppealId);
             iojAppealService.delete(appealEntity);
             throw new AssessmentServiceException(String.format(
-                "Error linking appealId %s to legacyAppealId %d, creation has been rolled back: %s",
-                appealEntity.getAppealId().toString(), legacyAppealId, exc.getMessage()));
+                    "Error linking appealId %s to legacyAppealId %d, creation has been rolled back: %s",
+                    appealEntity.getAppealId().toString(), legacyAppealId, exc.getMessage()));
         }
 
         return appealEntity;

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/IojAppealDualWriteService.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/IojAppealDualWriteService.java
@@ -2,7 +2,7 @@ package uk.gov.justice.laa.crime.assessmentservice.iojappeal.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import uk.gov.justice.laa.crime.assessmentservice.common.exception.AssessmentServiceException;
+import uk.gov.justice.laa.crime.assessmentservice.common.exception.AssessmentRollbackException;
 import uk.gov.justice.laa.crime.assessmentservice.iojappeal.entity.IojAppealEntity;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealRequest;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealResponse;
@@ -30,7 +30,7 @@ public class IojAppealDualWriteService {
         } catch (Exception exc) {
             legacyIojAppealService.rollback(legacyAppealId);
             iojAppealService.delete(appealEntity);
-            throw new AssessmentServiceException(String.format(
+            throw new AssessmentRollbackException(String.format(
                     "Error linking appealId %s to legacyAppealId %d, creation has been rolled back: %s",
                     appealEntity.getAppealId().toString(), legacyAppealId, exc.getMessage()));
         }

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/IojAppealService.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/IojAppealService.java
@@ -36,4 +36,8 @@ public class IojAppealService {
     public IojAppealEntity save(IojAppealEntity iojAppealEntity) {
         return iojAppealRepository.save(iojAppealEntity);
     }
+
+    public void delete(IojAppealEntity iojAppealEntity) {
+        iojAppealRepository.delete(iojAppealEntity);
+    }
 }

--- a/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/LegacyIojAppealService.java
+++ b/crime-assessment-service/src/main/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/LegacyIojAppealService.java
@@ -36,4 +36,8 @@ public class LegacyIojAppealService {
     public ApiCreateIojAppealResponse create(ApiCreateIojAppealRequest request) {
         return maatCourtDataApiClient.createIojAppeal(request);
     }
+
+    public void rollback(int legacyAppealId) {
+        maatCourtDataApiClient.rollbackIojAppeal(legacyAppealId);
+    }
 }

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/IojAppealIntegrationTest.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/IojAppealIntegrationTest.java
@@ -20,6 +20,7 @@ import uk.gov.justice.laa.crime.assessmentservice.CrimeAssessmentTestConfigurati
 import uk.gov.justice.laa.crime.assessmentservice.iojappeal.entity.IojAppealEntity;
 import uk.gov.justice.laa.crime.assessmentservice.iojappeal.repository.IojAppealRepository;
 import uk.gov.justice.laa.crime.assessmentservice.iojappeal.service.IojAppealService;
+import uk.gov.justice.laa.crime.assessmentservice.utils.TestConstants;
 import uk.gov.justice.laa.crime.assessmentservice.utils.TestDataBuilder;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealResponse;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiGetIojAppealResponse;
@@ -63,15 +64,12 @@ import com.jayway.jsonpath.JsonPath;
 class IojAppealIntegrationTest {
 
     private MockMvc mvc;
-
-    private static final UUID APPEAL_ID = UUID.fromString("04a0d8a7-127a-44d0-bef1-d020e4ddc608");
-    private static final Integer LEGACY_APPEAL_ID = 1001;
     private static final String BEARER_TOKEN = "Bearer token";
     private static final String ENDPOINT_URL = "/api/internal/v1/ioj-appeals";
-    private static final String ENDPOINT_URL_FIND = ENDPOINT_URL + "/" + APPEAL_ID;
+    private static final String ENDPOINT_URL_FIND = ENDPOINT_URL + "/" + TestConstants.APPEAL_ID;
     private static final String ENDPOINT_URL_FIND_LEGACY = ENDPOINT_URL + "/lookup-by-legacy-id";
     private static final String MAAT_API_APPEAL_URL = "/api/internal/v2/assessment/ioj-appeals";
-    private static final String MAAT_API_APPEAL_ROLLBACK_URL = MAAT_API_APPEAL_URL + "/rollback/" + LEGACY_APPEAL_ID;
+    private static final String MAAT_API_APPEAL_ROLLBACK_URL = MAAT_API_APPEAL_URL + "/rollback/" + TestConstants.LEGACY_APPEAL_ID;
 
     @InjectWireMock
     private static WireMockServer wiremock;
@@ -156,7 +154,7 @@ class IojAppealIntegrationTest {
     @Test
     void givenAppealExistsInLegacy_whenFindLegacyIojAppealIsInvoked_thenReturnsAppeal() throws Exception {
         ApiGetIojAppealResponse response = new ApiGetIojAppealResponse()
-                .withAppealId(APPEAL_ID.toString())
+                .withAppealId(TestConstants.APPEAL_ID)
                 .withLegacyAppealId(223)
                 .withReceivedDate(LocalDate.of(2025, 2, 1))
                 .withAppealReason(NewWorkReason.NEW)
@@ -192,7 +190,7 @@ class IojAppealIntegrationTest {
     void givenValidCreateRequest_whenCreateIsInvoked_thenSuccess() throws Exception {
         var request = TestDataBuilder.buildValidPopulatedCreateIojAppealRequest();
         var initialAppealCount = iojAppealRepository.count();
-        var response = new ApiCreateIojAppealResponse().withLegacyAppealId(LEGACY_APPEAL_ID);
+        var response = new ApiCreateIojAppealResponse().withLegacyAppealId(TestConstants.LEGACY_APPEAL_ID);
 
         wiremock.stubFor(post(urlEqualTo(MAAT_API_APPEAL_URL))
                 .willReturn(WireMock.ok()
@@ -237,7 +235,7 @@ class IojAppealIntegrationTest {
     void givenUpdateFailure_whenCreateIsInvoked_thenAppealIsWritten() throws Exception {
         var request = TestDataBuilder.buildValidPopulatedCreateIojAppealRequest();
         var initialAppealCount = iojAppealRepository.count();
-        var response = new ApiCreateIojAppealResponse().withLegacyAppealId(LEGACY_APPEAL_ID);
+        var response = new ApiCreateIojAppealResponse().withLegacyAppealId(TestConstants.LEGACY_APPEAL_ID);
         doThrow(new RuntimeException("Test Exception")).when(iojAppealService).save(any(IojAppealEntity.class));
 
         wiremock.stubFor(post(urlEqualTo(MAAT_API_APPEAL_URL))

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/IojAppealIntegrationTest.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/IojAppealIntegrationTest.java
@@ -69,7 +69,8 @@ class IojAppealIntegrationTest {
     private static final String ENDPOINT_URL_FIND = ENDPOINT_URL + "/" + TestConstants.APPEAL_ID;
     private static final String ENDPOINT_URL_FIND_LEGACY = ENDPOINT_URL + "/lookup-by-legacy-id";
     private static final String MAAT_API_APPEAL_URL = "/api/internal/v2/assessment/ioj-appeals";
-    private static final String MAAT_API_APPEAL_ROLLBACK_URL = MAAT_API_APPEAL_URL + "/rollback/" + TestConstants.LEGACY_APPEAL_ID;
+    private static final String MAAT_API_APPEAL_ROLLBACK_URL =
+            MAAT_API_APPEAL_URL + "/rollback/" + TestConstants.LEGACY_APPEAL_ID;
 
     @InjectWireMock
     private static WireMockServer wiremock;

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/IojAppealDualWriteServiceTest.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/IojAppealDualWriteServiceTest.java
@@ -1,17 +1,11 @@
 package uk.gov.justice.laa.crime.assessmentservice.iojappeal.service;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.sql.SQLException;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.laa.crime.assessmentservice.common.exception.AssessmentServiceException;
 import uk.gov.justice.laa.crime.assessmentservice.iojappeal.entity.IojAppealEntity;
 import uk.gov.justice.laa.crime.assessmentservice.utils.TestConstants;
@@ -19,13 +13,21 @@ import uk.gov.justice.laa.crime.assessmentservice.utils.TestDataBuilder;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealRequest;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealResponse;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 @ExtendWith(MockitoExtension.class)
 public class IojAppealDualWriteServiceTest {
 
     @Mock
     private IojAppealService iojAppealService;
+
     @Mock
     private LegacyIojAppealService legacyIojAppealService;
+
     @InjectMocks
     private IojAppealDualWriteService iojAppealDualWriteService;
 
@@ -36,8 +38,8 @@ public class IojAppealDualWriteServiceTest {
         IojAppealEntity entity = TestDataBuilder.buildIojAppealEntity();
 
         when(iojAppealService.create(any(ApiCreateIojAppealRequest.class))).thenReturn(entity);
-        when(legacyIojAppealService.create(any(ApiCreateIojAppealRequest.class))).thenReturn(
-            response);
+        when(legacyIojAppealService.create(any(ApiCreateIojAppealRequest.class)))
+                .thenReturn(response);
 
         IojAppealEntity result = iojAppealDualWriteService.createIojAppeal(request);
 
@@ -52,16 +54,16 @@ public class IojAppealDualWriteServiceTest {
         IojAppealEntity entity = TestDataBuilder.buildIojAppealEntity(true);
 
         when(iojAppealService.create(any(ApiCreateIojAppealRequest.class))).thenReturn(entity);
-        when(legacyIojAppealService.create(any(ApiCreateIojAppealRequest.class))).thenReturn(
-            response);
-        when(iojAppealService.save(any(IojAppealEntity.class))).thenThrow(
-            new IllegalArgumentException("Test exception."));
+        when(legacyIojAppealService.create(any(ApiCreateIojAppealRequest.class)))
+                .thenReturn(response);
+        when(iojAppealService.save(any(IojAppealEntity.class)))
+                .thenThrow(new IllegalArgumentException("Test exception."));
 
         assertThatThrownBy(() -> iojAppealDualWriteService.createIojAppeal(request))
-            .isInstanceOf(AssessmentServiceException.class)
-            .hasMessage(String.format(
-                "Error linking appealId %s to legacyAppealId %s, creation has been rolled back: %s",
-                TestConstants.APPEAL_ID, TestConstants.LEGACY_APPEAL_ID, "Test exception."));
+                .isInstanceOf(AssessmentServiceException.class)
+                .hasMessage(String.format(
+                        "Error linking appealId %s to legacyAppealId %s, creation has been rolled back: %s",
+                        TestConstants.APPEAL_ID, TestConstants.LEGACY_APPEAL_ID, "Test exception."));
         verify(legacyIojAppealService).rollback(TestConstants.LEGACY_APPEAL_ID);
         verify(iojAppealService).delete(entity);
     }

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/IojAppealDualWriteServiceTest.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/IojAppealDualWriteServiceTest.java
@@ -1,2 +1,68 @@
-package uk.gov.justice.laa.crime.assessmentservice.iojappeal.service;public class IojAppealDualWriteServiceTest {
+package uk.gov.justice.laa.crime.assessmentservice.iojappeal.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.SQLException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.laa.crime.assessmentservice.common.exception.AssessmentServiceException;
+import uk.gov.justice.laa.crime.assessmentservice.iojappeal.entity.IojAppealEntity;
+import uk.gov.justice.laa.crime.assessmentservice.utils.TestConstants;
+import uk.gov.justice.laa.crime.assessmentservice.utils.TestDataBuilder;
+import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealRequest;
+import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealResponse;
+
+@ExtendWith(MockitoExtension.class)
+public class IojAppealDualWriteServiceTest {
+
+    @Mock
+    private IojAppealService iojAppealService;
+    @Mock
+    private LegacyIojAppealService legacyIojAppealService;
+    @InjectMocks
+    private IojAppealDualWriteService iojAppealDualWriteService;
+
+    @Test
+    void givenValidRequest_whenCreateIojAppealIsInvoked_thenIojIsCreatedAndLinked() {
+        ApiCreateIojAppealRequest request = TestDataBuilder.buildValidPopulatedCreateIojAppealRequest();
+        ApiCreateIojAppealResponse response = TestDataBuilder.buildValidPopulatedCreateIojAppealResponse();
+        IojAppealEntity entity = TestDataBuilder.buildIojAppealEntity();
+
+        when(iojAppealService.create(any(ApiCreateIojAppealRequest.class))).thenReturn(entity);
+        when(legacyIojAppealService.create(any(ApiCreateIojAppealRequest.class))).thenReturn(
+            response);
+
+        IojAppealEntity result = iojAppealDualWriteService.createIojAppeal(request);
+
+        assertThat(result.getLegacyAppealId()).isEqualTo(TestConstants.LEGACY_APPEAL_ID);
+        verify(iojAppealService).save(entity);
+    }
+
+    @Test
+    void givenExceptionDuringLinking_whenCreateIojAppealIsInvoked_thenIojIsRolledBack() {
+        ApiCreateIojAppealRequest request = TestDataBuilder.buildValidPopulatedCreateIojAppealRequest();
+        ApiCreateIojAppealResponse response = TestDataBuilder.buildValidPopulatedCreateIojAppealResponse();
+        IojAppealEntity entity = TestDataBuilder.buildIojAppealEntity(true);
+
+        when(iojAppealService.create(any(ApiCreateIojAppealRequest.class))).thenReturn(entity);
+        when(legacyIojAppealService.create(any(ApiCreateIojAppealRequest.class))).thenReturn(
+            response);
+        when(iojAppealService.save(any(IojAppealEntity.class))).thenThrow(
+            new IllegalArgumentException("Test exception."));
+
+        assertThatThrownBy(() -> iojAppealDualWriteService.createIojAppeal(request))
+            .isInstanceOf(AssessmentServiceException.class)
+            .hasMessage(String.format(
+                "Error linking appealId %s to legacyAppealId %s, creation has been rolled back: %s",
+                TestConstants.APPEAL_ID, TestConstants.LEGACY_APPEAL_ID, "Test exception."));
+        verify(legacyIojAppealService).rollback(TestConstants.LEGACY_APPEAL_ID);
+        verify(iojAppealService).delete(entity);
+    }
 }

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/IojAppealDualWriteServiceTest.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/IojAppealDualWriteServiceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import uk.gov.justice.laa.crime.assessmentservice.common.exception.AssessmentServiceException;
+import uk.gov.justice.laa.crime.assessmentservice.common.exception.AssessmentRollbackException;
 import uk.gov.justice.laa.crime.assessmentservice.iojappeal.entity.IojAppealEntity;
 import uk.gov.justice.laa.crime.assessmentservice.utils.TestConstants;
 import uk.gov.justice.laa.crime.assessmentservice.utils.TestDataBuilder;
@@ -60,7 +60,7 @@ public class IojAppealDualWriteServiceTest {
                 .thenThrow(new IllegalArgumentException("Test exception."));
 
         assertThatThrownBy(() -> iojAppealDualWriteService.createIojAppeal(request))
-                .isInstanceOf(AssessmentServiceException.class)
+                .isInstanceOf(AssessmentRollbackException.class)
                 .hasMessage(String.format(
                         "Error linking appealId %s to legacyAppealId %s, creation has been rolled back: %s",
                         TestConstants.APPEAL_ID, TestConstants.LEGACY_APPEAL_ID, "Test exception."));

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/IojAppealDualWriteServiceTest.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/iojappeal/service/IojAppealDualWriteServiceTest.java
@@ -1,0 +1,2 @@
+package uk.gov.justice.laa.crime.assessmentservice.iojappeal.service;public class IojAppealDualWriteServiceTest {
+}

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/utils/TestConstants.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/utils/TestConstants.java
@@ -1,0 +1,9 @@
+package uk.gov.justice.laa.crime.assessmentservice.utils;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class TestConstants {
+    public String APPEAL_ID = "04a0d8a7-127a-44d0-bef1-d020e4ddc608";
+    public Integer LEGACY_APPEAL_ID = 1001;
+}

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/utils/TestDataBuilder.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/utils/TestDataBuilder.java
@@ -44,8 +44,8 @@ public class TestDataBuilder {
 
     public ApiCreateIojAppealResponse buildValidPopulatedCreateIojAppealResponse() {
         return new ApiCreateIojAppealResponse()
-            .withAppealId(TestConstants.APPEAL_ID)
-            .withLegacyAppealId(TestConstants.LEGACY_APPEAL_ID);
+                .withAppealId(TestConstants.APPEAL_ID)
+                .withLegacyAppealId(TestConstants.LEGACY_APPEAL_ID);
     }
 
     public IojAppealEntity buildIojAppealEntity(boolean setRandomId) {

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/utils/TestDataBuilder.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/utils/TestDataBuilder.java
@@ -4,6 +4,7 @@ import lombok.experimental.UtilityClass;
 import uk.gov.justice.laa.crime.assessmentservice.iojappeal.entity.IojAppealEntity;
 import uk.gov.justice.laa.crime.common.model.common.ApiUserSession;
 import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealRequest;
+import uk.gov.justice.laa.crime.common.model.ioj.ApiCreateIojAppealResponse;
 import uk.gov.justice.laa.crime.common.model.ioj.IojAppeal;
 import uk.gov.justice.laa.crime.common.model.ioj.IojAppealMetadata;
 import uk.gov.justice.laa.crime.enums.IojAppealAssessor;
@@ -41,9 +42,15 @@ public class TestDataBuilder {
         return request;
     }
 
+    public ApiCreateIojAppealResponse buildValidPopulatedCreateIojAppealResponse() {
+        return new ApiCreateIojAppealResponse()
+            .withAppealId(TestConstants.APPEAL_ID)
+            .withLegacyAppealId(TestConstants.LEGACY_APPEAL_ID);
+    }
+
     public IojAppealEntity buildIojAppealEntity(boolean setRandomId) {
         return IojAppealEntity.builder()
-                .legacyAppealId(1234)
+                .legacyAppealId(TestConstants.LEGACY_APPEAL_ID)
                 .legacyApplicationId(223)
                 .receivedDate(LocalDate.of(2025, 2, 1))
                 .appealReason(NewWorkReason.NEW.getCode())
@@ -54,7 +61,7 @@ public class TestDataBuilder {
                 .decisionDate(LocalDate.of(2025, 2, 8))
                 .caseManagementUnitId(44)
                 .createdBy("tester")
-                .appealId((setRandomId ? UUID.randomUUID() : null))
+                .appealId((setRandomId ? UUID.fromString(TestConstants.APPEAL_ID) : null))
                 .build();
     }
 

--- a/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/utils/TestDataBuilder.java
+++ b/crime-assessment-service/src/test/java/uk/gov/justice/laa/crime/assessmentservice/utils/TestDataBuilder.java
@@ -48,7 +48,7 @@ public class TestDataBuilder {
                 .withLegacyAppealId(TestConstants.LEGACY_APPEAL_ID);
     }
 
-    public IojAppealEntity buildIojAppealEntity(boolean setRandomId) {
+    public IojAppealEntity buildIojAppealEntity(boolean setAppealId) {
         return IojAppealEntity.builder()
                 .legacyAppealId(TestConstants.LEGACY_APPEAL_ID)
                 .legacyApplicationId(223)
@@ -61,7 +61,7 @@ public class TestDataBuilder {
                 .decisionDate(LocalDate.of(2025, 2, 8))
                 .caseManagementUnitId(44)
                 .createdBy("tester")
-                .appealId((setRandomId ? UUID.fromString(TestConstants.APPEAL_ID) : null))
+                .appealId((setAppealId ? UUID.fromString(TestConstants.APPEAL_ID) : null))
                 .build();
     }
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1923)

Added logic to rollback the creation of the IoJ Appeal both in the local Postgres database and on the MAAT database via MAAT Court Data API, when an exception is encountered trying to link both records with the legacy appeal ID. In this case the local record is deleted and the record on MAAT database is soft deleted by setting the replace value to 'Y' see https://github.com/ministryofjustice/laa-maat-court-data-api/pull/1143. Then an exception is raised which will return a 555 response to the Orchestration service.

## Checklist

Before you ask people to review this PR:

- [x] The pull request is not labelled as *WIP/DRAFT* and has a title format of *LCAM/LASB-XXXX - Description*.
- [x] A link to the Jira ticket is provided along with a description giving context and rationale for the changes.
- [x] Github is not reporting any conflicts with the main branch.
- [x] All of the pull request triggered checks (such as Build and Test, CodeQL and Snyk) have passed.
- [x] Nothing unexpected is included in the changes when compared to the main branch.
- [x] The commit messages have meaningful descriptions.
- [ ] Relevant areas in the documentation have been updated to reflect the changes.
- [ ] There has been no regressions in the [Functional Test Suite](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions) when run in the TEST environment.
