### PR TITLE
[LCAM-1931] Remove port from maatApi baseUrl

### DIFF
--- a/helm_deploy/crime-assessment-service/values-dev.yaml
+++ b/helm_deploy/crime-assessment-service/values-dev.yaml
@@ -30,7 +30,7 @@ service:
   targetPort: 8091
 
 maatApi:
-  baseUrl: http://laa-maat-data-api.laa-maat-data-api-dev.svc.cluster.local:8090
+  baseUrl: http://laa-maat-data-api.laa-maat-data-api-dev.svc.cluster.local
   oauthUrl: https://maat-api-dev.auth.eu-west-2.amazoncognito.com/oauth2/token
 
 # TODO ingress config

--- a/helm_deploy/crime-assessment-service/values-prod.yaml
+++ b/helm_deploy/crime-assessment-service/values-prod.yaml
@@ -30,7 +30,7 @@ service:
   targetPort: 8091
 
 maatApi:
-  baseUrl: http://laa-maat-data-api.laa-maat-data-api-prod.svc.cluster.local:8090
+  baseUrl: http://laa-maat-data-api.laa-maat-data-api-prod.svc.cluster.local
   oauthUrl: https://maat-api-prod.auth.eu-west-2.amazoncognito.com/oauth2/token
 
 ingress:

--- a/helm_deploy/crime-assessment-service/values-test.yaml
+++ b/helm_deploy/crime-assessment-service/values-test.yaml
@@ -30,7 +30,7 @@ service:
   targetPort: 8091
 
 maatApi:
-  baseUrl: http://laa-maat-data-api.laa-maat-data-api-test.svc.cluster.local:8090
+  baseUrl: http://laa-maat-data-api.laa-maat-data-api-test.svc.cluster.local
   oauthUrl: https://maat-api-test.auth.eu-west-2.amazoncognito.com/oauth2/token
 
 # TODO ingress config

--- a/helm_deploy/crime-assessment-service/values-uat.yaml
+++ b/helm_deploy/crime-assessment-service/values-uat.yaml
@@ -30,7 +30,7 @@ service:
   targetPort: 8091
 
 maatApi:
-  baseUrl: http://laa-maat-data-api.laa-maat-data-api-uat.svc.cluster.local:8090
+  baseUrl: http://laa-maat-data-api.laa-maat-data-api-uat.svc.cluster.local
   oauthUrl: https://maat-api-uat.auth.eu-west-2.amazoncognito.com/oauth2/token
 
 # TODO ingress config


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1931)

Removed the port number from the MAAT API baseUrl. I have made changes to MAAT API in this accompanying [PR](https://github.com/ministryofjustice/laa-maat-court-data-api/pull/1144), so that we no longer need to specify the port number when making requests using this internal URL on the cluster. 

I have tested the "Lookup by legacy ID" endpoint on all non-prod environments and it is working correctly. 

## Checklist

Before you ask people to review this PR:

- [x] The pull request is not labelled as *WIP/DRAFT* and has a title format of *LCAM/LASB-XXXX - Description*.
- [x] A link to the Jira ticket is provided along with a description giving context and rationale for the changes.
- [x] Github is not reporting any conflicts with the main branch.
- [x] All of the pull request triggered checks (such as Build and Test, CodeQL and Snyk) have passed.
- [x] Nothing unexpected is included in the changes when compared to the main branch.
- [x] The commit messages have meaningful descriptions.
- [ ] Relevant areas in the documentation have been updated to reflect the changes.
- [x] There has been no regressions in the [Functional Test Suite](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions) when run in the TEST environment.
