### PR TITLE
Resolve Issues With Swagger UI and Spring Doc Vulnerability

### DIFF
--- a/crime-assessment-service/build.gradle
+++ b/crime-assessment-service/build.gradle
@@ -20,9 +20,10 @@ def versions = [
         sentry                      : "8.31.0",
         resilience4j                : "2.3.0",
         mapstruct                   : "1.6.3",
-        crimeCommonsClasses         : "4.32.0",
-        crimeCommonsModSchemas      : "1.47.0",
-        lombok                      : "1.18.42"
+        crimeCommonsClasses         : "4.33.0",
+        crimeCommonsModSchemas      : "1.50.0",
+        lombok                      : "1.18.42",
+        springdoc                   : "2.8.16"
 ]
 
 repositories {
@@ -89,7 +90,7 @@ dependencies {
     testImplementation 'org.wiremock.integrations:wiremock-spring-boot:3.10.6'
 
     // Documentation
-    implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15"
+    implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:$versions.springdoc"
 
     compileOnly "org.projectlombok:lombok:$versions.lombok"
     annotationProcessor "org.projectlombok:lombok:$versions.lombok"


### PR DESCRIPTION
## What

- Bumped version of springdoc to resolve Snyk flagged vulnerability https://app.snyk.io/org/legal-aid-agency/project/54d650ea-e41b-4603-a809-dbe59752daf8.
- Bumped version of crime commons modules which was causing swagger ui to not display due to swagger annotation version mismatch (crime commons using older version).

## Checklist

Before you ask people to review this PR:

- [ ] The pull request is not labelled as *WIP/DRAFT* and has a title format of *LCAM/LASB-XXXX - Description*.
- [ ] A link to the Jira ticket is provided along with a description giving context and rationale for the changes.
- [ ] Github is not reporting any conflicts with the main branch.
- [ ] All of the pull request triggered checks (such as Build and Test, CodeQL and Snyk) have passed.
- [ ] Nothing unexpected is included in the changes when compared to the main branch.
- [ ] The commit messages have meaningful descriptions.
- [ ] Relevant areas in the documentation have been updated to reflect the changes.
- [ ] There has been no regressions in the [Functional Test Suite](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions) when run in the TEST environment.
