### PR TITLE
LCAM-2130: update springboot+tomcat versions to stop CVE error in build

### DIFF
--- a/crime-assessment-service/build.gradle
+++ b/crime-assessment-service/build.gradle
@@ -3,12 +3,12 @@ plugins {
     id 'jacoco'
     id "com.diffplug.spotless" version "8.0.0"
     id 'com.adarshr.test-logger' version '4.0.0'
-    id 'org.springframework.boot' version '3.5.8'
+    id 'org.springframework.boot' version '3.5.14'
     id "com.github.ben-manes.versions" version "0.52.0"
 }
 
 // springboot tomcat version overide, can be removed when springboot is 3.5.15 or 4+
-// ext['tomcat.version'] = '10.1.55'
+ext['tomcat.version'] = '10.1.55'
 
 group = "uk.gov.justice.laa.crime"
 
@@ -32,7 +32,7 @@ def versions = [
 repositories {
     mavenCentral()
     maven {
-        url "https://central.sonatype.com/repository/maven-snapshots/"
+        url = "https://central.sonatype.com/repository/maven-snapshots/"
     }
 }
 

--- a/crime-assessment-service/build.gradle
+++ b/crime-assessment-service/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'jacoco'
     id "com.diffplug.spotless" version "8.0.0"
     id 'com.adarshr.test-logger' version '4.0.0'
-    id 'org.springframework.boot' version '3.5.7'
+    id 'org.springframework.boot' version '3.5.8'
     id "com.github.ben-manes.versions" version "0.52.0"
 }
 

--- a/crime-assessment-service/build.gradle
+++ b/crime-assessment-service/build.gradle
@@ -7,6 +7,9 @@ plugins {
     id "com.github.ben-manes.versions" version "0.52.0"
 }
 
+// springboot tomcat version overide, can be removed when springboot is 3.5.15 or 4+
+// ext['tomcat.version'] = '10.1.55'
+
 group = "uk.gov.justice.laa.crime"
 
 java {


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-2107)

update springboot and tomcat versions to fix reported CVE
springboot:3.5.14
tomcat: 10.1.55
Builds successfully, no SYNK warnings

[failing build](https://github.com/ministryofjustice/laa-crime-assessment-service/security/code-scanning?query=pr%3A60+tool%3A%22Snyk+Container%22+is%3Aopen)
[passing build](https://github.com/ministryofjustice/laa-crime-assessment-service/security/code-scanning?query=pr%3A60+tool%3ASnykCode+is%3Aopen)